### PR TITLE
Fix null dereference of 'progress' when updating an archive.  The callstack of the crash is:

### DIFF
--- a/CPP/7zip/Compress/ZstdDecoder.cpp
+++ b/CPP/7zip/Compress/ZstdDecoder.cpp
@@ -127,7 +127,10 @@ HRESULT CDecoder::CodeSpec(ISequentialInStream * inStream,
       if (zOut.pos) {
         RINOK(WriteStream(outStream, _dstBuf, zOut.pos));
         _processedOut += zOut.pos;
-        RINOK(progress->SetRatioInfo(&_processedIn, &_processedOut));
+        if (progress)
+        {
+          RINOK(progress->SetRatioInfo(&_processedIn, &_processedOut));
+        }
       }
 
       /* finished with buffer */


### PR DESCRIPTION
zstd-x64.dll!NCompress::NZSTD::CDecoder::CodeSpec(ISequentialInStream * inStream=0x000000001e6a2190, ISequentialOutStream * outStream=0x000000001e6b9460, ICompressProgressInfo * progress=0x0000000000000000) Line 130 C++
  zstd-x64.dll!NCompress::NZSTD::CDecoder::Code(ISequentialInStream * inStream=0x000000001e6a2190, ISequentialOutStream * outStream=0x000000001e6b9460, const unsigned __int64 * __formal=0x000000001e8a2d00, const unsigned __int64 * outSize=0x000000001e5eb3b0, ICompressProgressInfo * progress=0x0000000000000000) Line 177 C++
  7z.dll!NCoderMixer2::CCoderMT::Code(ICompressProgressInfo * progress=0x0000000000000000) Line 903 C++
  7z.dll!NCoderMixer2::CMixerMT::Code(ISequentialInStream * const * inStreams=0x000000001e8a2d20, ISequentialOutStream * const * outStreams=0x00000000219bf910, ICompressProgressInfo * progress=0x0000000000000000, bool & dataAfterEnd_Error=false) Line 1083 C++
  7z.dll!NArchive::N7z::CDecoder::Decode(const CExternalCodecs * __externalCodecs=0x000000001e599aa0, IInStream * inStream=0x000000001e8c6300, unsigned __int64 startPos=32, const NArchive::N7z::CFolders & folders={...}, unsigned int folderIndex=0, const unsigned __int64 * unpackSize=0x0000000000000000, ISequentialOutStream * outStream=0x000000001e6b9460, ICompressProgressInfo * compressProgress=0x0000000000000000, ISequentialInStream * * inStreamMainRes=0x0000000000000000, bool & dataAfterEnd_Error=false, ICryptoGetTextPassword * getTextPassword=0x000000001e6882b0, bool & isEncrypted=true, bool & passwordIsDefined=true, UString & password={...}, bool mtMode=false, unsigned int numThreads=1, unsigned __int64 memUsage=0) Line 555 C++
  7z.dll!NArchive::N7z::CThreadDecoder::Execute() Line 1493 C++
  7z.dll!CoderThread(void * p=0x000000001f1cbe90) Line 16 C++

Other 7z threads are:

  7z.dll!Handle_WaitObject(void * h=0x0000000000000868) Line 32 C
  7z.dll!NWindows::NSynchronization::CBaseEvent::Lock() Line 47 C++
  7z.dll!CStreamBinder::Read(void * data=0x000000001e9b53ea, unsigned int size=115206, unsigned int * processedSize=0x000000001f1cb310) Line 95 C++
  7z.dll!CBinderInStream::Read(void * data=0x000000001e9b53ea, unsigned int size=115206, unsigned int * processedSize=0x000000001f1cb310) Line 22 C++
  7z.dll!COffsetOutStream::Write(const void * data=0x000000001e9b53ea, unsigned int size=115206, unsigned int * processedSize=0x000000001f1cb310) Line 19 C++
  7z.dll!CSequentialInStreamSizeCount2::Read(void * data=0x000000001e9b53ea, unsigned int size=115206, unsigned int * processedSize=0x000000001f1cb350) Line 10 C++
  zstd-x64.dll!ReadStream(ISequentialInStream * stream=0x000000001e7b4010, void * data=0x000000001e9b53ea, unsigned __int64 * processedSize=0x000000001f1cb3b8) Line 17 C++
  zstd-x64.dll!NCompress::NZSTD::CEncoder::Code(ISequentialInStream * inStream=0x000000001e7b4010, ISequentialOutStream * outStream=0x000000001e8e0dc0, const unsigned __int64 * __formal=0x0000000000000000, const unsigned __int64 * __formal=0x0000000000000000, ICompressProgressInfo * progress=0x000000001b6df8d0) Line 329 C++
  7z.dll!NCoderMixer2::CCoderMT::Code(ICompressProgressInfo * progress=0x000000001b6df8d0) Line 903 C++
  7z.dll!NCoderMixer2::CMixerMT::Code(ISequentialInStream * const * inStreams=0x000000001f1cb750, ISequentialOutStream * const * outStreams=0x000000001e599bc0, ICompressProgressInfo * progress=0x000000001b6df8d0, bool & dataAfterEnd_Error=false) Line 1083 C++
  7z.dll!NArchive::N7z::CEncoder::Encode(const CExternalCodecs * __externalCodecs=0x000000001e599aa0, ISequentialInStream * inStream=0x000000001e7b3f10, const unsigned __int64 * inSizeForReduce=0x000000001f1cb960, NArchive::N7z::CFolder & folderItem={...}, CRecordVector<unsigned __int64> & coderUnpackSizes={...}, unsigned __int64 & unpackSize=17468, ISequentialOutStream * outStream=0x000000001e8bcdd0, CRecordVector<unsigned __int64> & packSizes={...}, ICompressProgressInfo * compressProgress=0x000000001b6df8d0) Line 454 C++
  7z.dll!NArchive::N7z::Update(const CExternalCodecs * __externalCodecs=0x000000001e599aa0, IInStream * inStream=0x000000001e8c6300, const NArchive::N7z::CDbEx * db=0x000000001e5998a8, const CObjectVector<NArchive::N7z::CUpdateItem> & updateItems={...}, NArchive::N7z::COutArchive & archive={...}, NArchive::N7z::CArchiveDatabaseOut & newDatabase={...}, ISequentialOutStream * seqOutStream=0x000000001e8bcdd0, IArchiveUpdateCallback * updateCallback=0x000000001f1cc980, const NArchive::N7z::CUpdateOptions & options={...}, ICryptoGetTextPassword * getDecoderPassword=0x000000001f1cc958) Line 2178 C++
  7z.dll!NArchive::N7z::CHandler::UpdateItems(ISequentialOutStream * outStream=0x000000001e8bcdd0, unsigned int numItems=10, IArchiveUpdateCallback * updateCallback=0x000000001f1cc980) Line 658 C++

And:

  7z.dll!Handle_WaitObject(void * h=0x0000000000000880) Line 32 C
  7z.dll!NWindows::NSynchronization::CBaseEvent::Lock() Line 47 C++
  7z.dll!CStreamBinder::Read(void * data=0x0000000020650000, unsigned int size=1048576, unsigned int * processedSize=0x000000002084f6d0) Line 95 C++
  7z.dll!CBinderInStream::Read(void * data=0x0000000020650000, unsigned int size=1048576, unsigned int * processedSize=0x000000002084f6d0) Line 22 C++
  7z.dll!ReadStream(ISequentialInStream * stream=0x000000001e8e0de0, void * data=0x0000000020650000, unsigned __int64 * processedSize=0x000000002084f758) Line 17 C++
  7z.dll!CFilterCoder::Code(ISequentialInStream * inStream=0x000000001e8e0de0, ISequentialOutStream * outStream=0x000000001e55da30, const unsigned __int64 * __formal=0x0000000000000000, const unsigned __int64 * outSize=0x0000000000000000, ICompressProgressInfo * progress=0x0000000000000000) Line 83 C++
  7z.dll!NCoderMixer2::CCoderMT::Code(ICompressProgressInfo * progress=0x0000000000000000) Line 903 C++
  7z.dll!NCoderMixer2::CCoderMT::Execute() Line 867 C++
  7z.dll!CoderThread(void * p=0x000000001e5eb510) Line 16 C++