### PR TITLE
change hot-key ALT+UP, add CTRL+RIGHT/LEFT

### DIFF
--- a/CPP/7zip/UI/FileManager/PanelKey.cpp
+++ b/CPP/7zip/UI/FileManager/PanelKey.cpp
@@ -198,7 +198,7 @@ bool CPanel::OnKeyDown(LPNMLVKEYDOWN keyDownInfo, LRESULT &result)
     case VK_UP:
     {
       if (alt)
-        _panelCallback->OnSetSameFolder();
+        OpenParentFolder();
       else if (shift)
         OnArrowWithShift();
       return false;
@@ -209,6 +209,8 @@ bool CPanel::OnKeyDown(LPNMLVKEYDOWN keyDownInfo, LRESULT &result)
         _panelCallback->OnSetSubFolder();
       else if (shift)
         OnArrowWithShift();
+      else if (ctrl)
+        _panelCallback->OnSetSameFolder();
       return false;
     }
     case VK_LEFT:
@@ -217,6 +219,8 @@ bool CPanel::OnKeyDown(LPNMLVKEYDOWN keyDownInfo, LRESULT &result)
         _panelCallback->OnSetSubFolder();
       else if (shift)
         OnArrowWithShift();
+      else if (ctrl)
+        _panelCallback->OnSetSameFolder();
       return false;
     }
     case VK_NEXT:


### PR DESCRIPTION
Windows Explorer and TotalCommander use ALT+UP as a hotkey to return to the upper level of the directory, but 7-ZIP defines it as synchronizing the path of the current panel to another panel, which often leads to incorrect operations.
Now change it to the same behavior mode as the above application, and add hotkeys CTRL+LEFT and CTRL+RIGHT to provide the function of synchronizing the panel path, which is similar but not exactly the same as TotalCommander.