### PR TITLE
Correct recognition of zstd properties like -m0=zstd:long, etc

### DIFF
--- a/CPP/7zip/Common/MethodProps.cpp
+++ b/CPP/7zip/Common/MethodProps.cpp
@@ -297,6 +297,8 @@ static const CNameToPropID g_NameToPropID[] =
   { VT_UI4, "check" },
   { VT_BSTR, "filter" },
   { VT_UI8, "memuse" },
+  { VT_UI8, "aff" },
+  // zstd props
   { VT_UI4, "strat" },
   { VT_UI4, "fast" },
   { VT_UI4, "long" },


### PR DESCRIPTION
The proposed PR fixes the mismatch between `g_NameToPropID` and `NCoderPropID` (restores correct map of zstd props) which got broken by update to 7-Zip v.21.02 (48fa49f76c2cd81e50240785da16a5ca9fe9734c introduced new property `NCoderPropID::kAffinity`):
https://github.com/mcmilk/7-Zip-zstd/blob/48fa49f76c2cd81e50240785da16a5ca9fe9734c/CPP/7zip/ICoder.h#L135

Without this fix every zstd property set is basically shifted to 1 position, so almost nothing works properly in `CEncoder::SetCoderProperties` starting from
https://github.com/mcmilk/7-Zip-zstd/blob/3724ecfedc91ea275dfbc88b8e7acf2f7be02c83/CPP/7zip/Compress/ZstdEncoder.cpp#L67
because the `switch` searching for completely different enum-value.

For instance it was impossible to switch to ultra fast compression (`:fast`), set long distance matching (`:long`) etc, so calling of `7z` or `7za` with `-m0=zstd:long` did nothing previously. 
Here is diff as before/after fix:
```diff
  $ 7za.exe -y -m0=zstd -mx3 a silesia.tar.zstd silesia.tar | grep size
  Archive size: 66697913 bytes (64 MiB)
  $ 7za.exe -y -m0=zstd:long -mx3 a silesia.tar.zstd silesia.tar | grep size
- Archive size: 66697913 bytes (64 MiB)
+ Archive size: 66143270 bytes (64 MiB)
```

Following table illustrating current mapping `g_NameToPropID` and `NCoderPropID`:
<details>

g_NameToPropID           | NCoderPropID
-------------------------|---------------------------------
 { VT_UI4, "" },         | kDefaultProp = 0,
 { VT_UI4, "d" },        | kDictionarySize,    // VT_UI4
 { VT_UI4, "mem" },      | kUsedMemorySize,    // VT_UI4
 { VT_UI4, "o" },        | kOrder,             // VT_UI4
 { VT_UI4, "c" },        | kBlockSize,         // VT_UI4 or VT_UI8
 { VT_UI4, "pb" },       | kPosStateBits,      // VT_UI4
 { VT_UI4, "lc" },       | kLitContextBits,    // VT_UI4
 { VT_UI4, "lp" },       | kLitPosBits,        // VT_UI4
 { VT_UI4, "fb" },       | kNumFastBytes,      // VT_UI4
 { VT_BSTR, "mf" },      | kMatchFinder,       // VT_BSTR
 { VT_UI4, "mc" },       | kMatchFinderCycles, // VT_UI4
 { VT_UI4, "pass" },     | kNumPasses,         // VT_UI4
 { VT_UI4, "a" },        | kAlgorithm,         // VT_UI4
 { VT_UI4, "mt" },       | kNumThreads,        // VT_UI4
 { VT_BOOL, "eos" },     | kEndMarker,         // VT_BOOL
 { VT_UI4, "x" },        | kLevel,             // VT_UI4
 { VT_UI8, "reduce" },   | kReduceSize,        // VT_UI8 
 { VT_UI8, "expect" },   | kExpectedDataSize,  // VT_UI8
 { VT_UI4, "b" },        | kBlockSize2,        // VT_UI4 or VT_UI8
 { VT_UI4, "check" },    | kCheckSize,         // VT_UI4
 { VT_BSTR, "filter" },  | kFilter,            // VT_BSTR
 { VT_UI8, "memuse" },   | kMemUse,            // VT_UI8
&nbsp; | &nbsp;
 \+ { VT_UI8, "aff" },    | kAffinity,          // VT_UI8
&nbsp; | &nbsp;
 // zstd props           | /* zstd props */
 { VT_UI4, "strat" },    | kStrategy,          // VT_UI4 
 { VT_UI4, "fast" },     | kFast,              // VT_UI4 
 { VT_UI4, "long" },     | kLong,              // VT_UI4 
 { VT_UI4, "wlog" },     | kWindowLog,         // VT_UI4 
 { VT_UI4, "hlog" },     | kHashLog,           // VT_UI4 
 { VT_UI4, "clog" },     | kChainLog,          // VT_UI4 
 { VT_UI4, "slog" },     | kSearchLog,         // VT_UI4 
 { VT_UI4, "slen" },     | kMinMatch,          // VT_UI4 
 { VT_UI4, "tlen" },     | kTargetLen,         // VT_UI4 
 { VT_UI4, "ovlog" },    | kOverlapLog,        // VT_UI4 
 { VT_UI4, "ldmhlog" },  | kLdmHashLog,        // VT_UI4 
 { VT_UI4, "ldmslen" },  | kLdmSearchLength,   // VT_UI4 
 { VT_UI4, "ldmblog" },  | kLdmBucketSizeLog,  // VT_UI4 
 { VT_UI4, "ldmhevery" } | kLdmHashRateLog     // VT_UI4 
</details>