### PR TITLE
Prevent errors of unexpected difference between g_NameToPropID and NCoderPropID

### DIFF
--- a/CPP/7zip/Common/MethodProps.cpp
+++ b/CPP/7zip/Common/MethodProps.cpp
@@ -331,6 +331,11 @@ static const CNameToPropID g_NameToPropID[] =
   { VT_UI4, "ldmhevery" }
 };
 
+#if defined(static_assert) || (__STDC_VERSION >= 201112L) || (_MSC_VER >= 1900)
+  static_assert(ARRAY_SIZE(g_NameToPropID) == NCoderPropID::kEndOfProp,
+    "g_NameToPropID doesn't match NCoderPropID enum");
+#endif
+
 static int FindPropIdExact(const UString &name)
 {
   for (unsigned i = 0; i < ARRAY_SIZE(g_NameToPropID); i++)

--- a/CPP/7zip/ICoder.h
+++ b/CPP/7zip/ICoder.h
@@ -148,7 +148,8 @@ namespace NCoderPropID
     kLdmHashLog,        // VT_UI4 The minimum ldmhlog is 6 and the maximum is 26 (default: 20).
     kLdmSearchLength,   // VT_UI4 The minimum ldmslen is 4 and the maximum is 4096 (default: 64).
     kLdmBucketSizeLog,  // VT_UI4 The minimum ldmblog is 0 and the maximum is 8 (default: 3).
-    kLdmHashRateLog     // VT_UI4 The default value is wlog - ldmhlog.
+    kLdmHashRateLog,    // VT_UI4 The default value is wlog - ldmhlog.
+    kEndOfProp
   };
 }
 


### PR DESCRIPTION
This is a small amend to #222, preventing consistency errors by unexpected growing of properties enum e. g. by future merge with upstream.
In compilers supporting constexpr/static_assert it would now check its length at compile time:
`ARRAY_SIZE(g_NameToPropID)` must be always equal `NCoderPropID::kEndOfProp`
