### PR TITLE
fix -Werror build (22.01)

### DIFF
--- a/CPP/7zip/Compress/ZstdDecoder.cpp
+++ b/CPP/7zip/Compress/ZstdDecoder.cpp
@@ -81,7 +81,9 @@ HRESULT CDecoder::CodeSpec(ISequentialInStream * inStream,
     if (ZSTD_isError(result))
       return E_OUTOFMEMORY;
   } else {
-    ZSTD_resetDStream(_ctx);
+    result = ZSTD_DCtx_reset(_ctx, ZSTD_reset_session_only);
+    if (ZSTD_isError(result))
+      return E_FAIL;
   }
 
   zOut.dst = _dstBuf;
@@ -136,7 +138,7 @@ HRESULT CDecoder::CodeSpec(ISequentialInStream * inStream,
 
       /* end of frame */
       if (result == 0) {
-        result = ZSTD_resetDStream(_ctx);
+        result = ZSTD_DCtx_reset(_ctx, ZSTD_reset_session_only);
         if (ZSTD_isError(result))
           return E_FAIL;
 

--- a/CPP/7zip/UI/Common/UpdateCallback.cpp
+++ b/CPP/7zip/UI/Common/UpdateCallback.cpp
@@ -58,6 +58,9 @@ bool InitLocalPrivileges();
 CArchiveUpdateCallback::CArchiveUpdateCallback():
     _hardIndex_From((UInt32)(Int32)-1),
     
+    VolNumberAfterExt(false),
+    DigitCount(2),
+
     Callback(NULL),
   
     DirItems(NULL),
@@ -92,9 +95,7 @@ CArchiveUpdateCallback::CArchiveUpdateCallback():
     Need_LatestMTime(false),
     LatestMTime_Defined(false),
     
-    ProcessedItemsStatuses(NULL),
-    VolNumberAfterExt(false),
-    DigitCount(2)
+    ProcessedItemsStatuses(NULL)
 {
   #ifdef _USE_SECURITY_CODE
   _saclEnabled = InitLocalPrivileges();


### PR DESCRIPTION
This PR resolves:
- usage of deprecated `ZSTD_resetDStream` (replaced with its equivalent `ZSTD_DCtx_reset(_ctx, ZSTD_reset_session_only);`)
- initialization order in constructor `CArchiveUpdateCallback` (doesn't match to members declaration order)

It'd silence two warnings, thus fixes errors in build with `-Werror`.
For instance build of 7za with gcc:
<details><summary>ZstdDecoder.cpp, [-Werror=deprecated-declarations]</summary>

```
../../Compress/ZstdDecoder.cpp: In member function 'HRESULT NCompress::NZSTD::CDecoder::CodeSpec(ISequentialInStream*, ISequentialOutStream*, ICompressProgressInfo*)':
../../Compress/ZstdDecoder.cpp:84:22: error: 'size_t ZSTD_resetDStream(ZSTD_DStream*)' is deprecated: use ZSTD_DCtx_reset, see zstd.h for detailed instructions [-Werror=deprecated-declarations]
   84 |     ZSTD_resetDStream(_ctx);
      |     ~~~~~~~~~~~~~~~~~^~~~~~
In file included from ../../Compress/ZstdDecoder.h:5,
                 from ../../Compress/ZstdDecoder.cpp:4:
C:/Projects/7-Zip-Ex/C/zstd/zstd.h:2603:27: note: declared here
 2603 | ZSTDLIB_STATIC_API size_t ZSTD_resetDStream(ZSTD_DStream* zds);
      |                           ^~~~~~~~~~~~~~~~~
../../Compress/ZstdDecoder.cpp:139:35: error: 'size_t ZSTD_resetDStream(ZSTD_DStream*)' is deprecated: use ZSTD_DCtx_reset, see zstd.h for detailed instructions [-Werror=deprecated-declarations]
  139 |         result = ZSTD_resetDStream(_ctx);
      |                  ~~~~~~~~~~~~~~~~~^~~~~~
C:/Projects/7-Zip-Ex/C/zstd/zstd.h:2603:27: note: declared here
 2603 | ZSTDLIB_STATIC_API size_t ZSTD_resetDStream(ZSTD_DStream* zds);
      |                           ^~~~~~~~~~~~~~~~~
cc1plus.exe: all warnings being treated as errors
```
</details>
<details><summary>UpdateCallback.cpp, [-Werror=reorder]</summary>

```
In file included from ../../UI/Common/UpdateCallback.cpp:36:
../../UI/Common/UpdateCallback.h: In constructor 'CArchiveUpdateCallback::CArchiveUpdateCallback()':
../../UI/Common/UpdateCallback.h:178:9: error: 'CArchiveUpdateCallback::ProcessedItemsStatuses' will be initialized after [-Werror=reorder]
  178 |   Byte *ProcessedItemsStatuses;
      |         ^~~~~~~~~~~~~~~~~~~~~~
../../UI/Common/UpdateCallback.h:140:8: error:   'bool CArchiveUpdateCallback::VolNumberAfterExt' [-Werror=reorder]
  140 |   bool VolNumberAfterExt;
      |        ^~~~~~~~~~~~~~~~~
../../UI/Common/UpdateCallback.cpp:58:1: error:   when initialized here [-Werror=reorder]
   58 | CArchiveUpdateCallback::CArchiveUpdateCallback():
      | ^~~~~~~~~~~~~~~~~~~~~~
cc1plus.exe: all warnings being treated as errors
```
</details>