### PR TITLE
BF: vulnerability by command line parsing (considers valid windows escape sequences)

### DIFF
--- a/CPP/Common/MyString.cpp
+++ b/CPP/Common/MyString.cpp
@@ -1206,6 +1206,16 @@ UString &UString::operator=(const UString &s)
   return *this;
 }
 
+void UString::AddFrom(const wchar_t *s, unsigned len) // no check
+{
+  if (len) {
+    Grow(len);
+    wmemcpy(_chars + _len, s, len);
+    _len += len;
+    _chars[_len] = 0;
+  }
+}
+
 void UString::SetFrom(const wchar_t *s, unsigned len) // no check
 {
   if (len > _limit)

--- a/CPP/Common/MyString.h
+++ b/CPP/Common/MyString.h
@@ -628,6 +628,7 @@ public:
   UString &operator=(char c) { return (*this)=((wchar_t)(unsigned char)c); }
   UString &operator=(const wchar_t *s);
   UString &operator=(const UString &s);
+  void AddFrom(const wchar_t *s, unsigned len); // no check
   void SetFrom(const wchar_t *s, unsigned len); // no check
   void SetFromBstr(LPCOLESTR s);
   UString &operator=(const char *s);


### PR DESCRIPTION
This PR provides a fix for certain vulnerability by command line parsing (considers valid windows escape sequences), like backslashes followed by quote-char as well as quote triples).

Windows command line processor (as well as programs and standard libraries constructing command line from arguments) use special escape and quoting sequences, so...

<details><summary>the proper scenario to parse command line looks like that...</summary>

- arguments are separated by spaces or tabs
- quotes serve as optional argument delimiters
  `"a b"` --> `a b`
- escaped quotes must be converted back to `"`
  `\"` --> `"`
- consecutive backslashes preceding a quote (inclusive closing quote for a parameter with spaces) see their number halved with
  the remainder escaping the quote:
  2n   backslashes + quote --> n backslashes + quote as an argument delimiter
  2n+1 backslashes + quote --> n backslashes + literal quote
- backslashes that are not followed by a quote are copied literally:
  `a\b` --> `a\b`
  `a\\b`  --> `a\\b`
- in quoted strings, consecutive quotes see their number divided by three
  with the remainder modulo 3 deciding whether to close the string or not.
  Note that the opening quote must be counted in the consecutive quotes,
  that's the (1+) below:
  (1+) 3n   quotes -> n quotes
  (1+) 3n+1 quotes -> n quotes plus closes the quoted string
  (1+) 3n+2 quotes -> n+1 quotes plus closes the quoted string
- in unquoted strings, the first quote opens the quoted string and the
  remaining consecutive quotes follow the above rule.

</details>
<details><summary>this causes following behavior by parsing of command line...</summary>

cmd line|arg1|arg2
---|---|---
abc" "def|abc def|
abc\\" \\"def|abc"|"def
"abc\\" \\"def"|abc" "def|
"abc"" ""def"|abc" "def|
abc"" ""def|abc|def
abc""" """def|abc" "def|
abc\\""" \\"""def|abc"|"def
abc\\\\""" \\\\"""def|abc\\" \\"def
"abc"""def" ghi"</sup>|abc"def ghi|
"abc"""def" ghi<br><sup>* missing close qoute at end</sup>|abc"def ghi|
"abc""def" ghi|abc"def|ghi
"abc\\"""def" ghi|abc""def|ghi
"abc\\\\"""def" ghi"|abc\\"def ghi|
"abc\\\\\\"""def" ghi|abc\\""def|ghi
"abc\\\\\\\\"""def" ghi"|abc\\\\"def ghi|
</details>

I know Windows doesn't allow quote-char in file or folder names, but command line could be built by some automation with a foreign user input and if it becomes validated using nominal condition of Windows parser, but hereafter processed in 7zip, as a consequence it could cause:

* misbehavior since the arguments can be parsed incorrectly (compared to default behavior of Windows parser) in the way that parts of quoted arguments may become unquoted and vice versa, as well as swim between different args;
* an attacker may create artificial command line that pass validation rules of nominal condition of Windows, but vulnerable here (inject, data steal, etc), because the arguments would deviate between validation and execution phase;
* (e. g. upon some future enhancements) special tokens like pipe `|`, ampersand `&` or redirecting tokens like `>` that normally included in quoted string (and validated as a string) could abrupt get different meaning and used for piping, redirecting etc, that beside the injection possibility opens still worse attacking vector that can even cause RCE or used to create persistent exploits.

Alternatively one could use windows API [CommandLineToArgvW](https://learn.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-commandlinetoargvw), but this would imply a modifying of `SplitCommandLine` interface as well as new dependency to shell32.dll.

With this fix `SplitCommandLine` works now very similar to `CommandLineToArgvW` (but doesn't require dependency to `shell32` library).