### PR TITLE
amend to #307, compatibility to CommandLineToArgvW or stdlib's main argument parsing

### DIFF
--- a/CPP/Common/CommandLineParser.cpp
+++ b/CPP/Common/CommandLineParser.cpp
@@ -51,7 +51,7 @@ static const wchar_t * _SplitCommandLine(const wchar_t* s, UString &dest)
           if (++qcount == 3)
           {
             dest += L'"';
-            qcount = 1;
+            qcount = 0;
           }
         }
         f = s;


### PR DESCRIPTION
amend to #307: more compatible to CommandLineToArgvW version by triple-quotes escape sequences (or double-quotes escape sequences in quotation).