### PR TITLE
Fixes string quotation in cmd-line from UI

### DIFF
--- a/CPP/7zip/UI/Common/CompressCall.cpp
+++ b/CPP/7zip/UI/Common/CompressCall.cpp
@@ -50,14 +50,6 @@ using namespace NWindows;
 static NCompression::CInfo m_RegistryInfo;
 extern HWND g_HWND;
 
-UString GetQuotedString(const UString &s)
-{
-  UString s2 ('\"');
-  s2 += s;
-  s2 += '\"';
-  return s2;
-}
-
 static void ErrorMessage(LPCWSTR message)
 {
   MessageBoxW(g_HWND, message, L"7-Zip ZS", MB_ICONERROR | MB_OK);

--- a/CPP/7zip/UI/Common/CompressCall.h
+++ b/CPP/7zip/UI/Common/CompressCall.h
@@ -5,8 +5,6 @@
 
 #include "../../../Common/MyString.h"
 
-UString GetQuotedString(const UString &s);
-
 HRESULT CompressFiles(
     const UString &arcPathPrefix,
     const UString &arcName,

--- a/CPP/7zip/UI/Common/CompressCall2.cpp
+++ b/CPP/7zip/UI/Common/CompressCall2.cpp
@@ -59,17 +59,6 @@ static void ThrowException_if_Error(HRESULT res)
 
 #endif
 
-
-
- 
-UString GetQuotedString(const UString &s)
-{
-  UString s2 ('\"');
-  s2 += s;
-  s2 += '\"';
-  return s2;
-}
-
 static void ErrorMessage(LPCWSTR message)
 {
   MessageBoxW(g_HWND, message, L"7-Zip ZS", MB_ICONERROR);

--- a/CPP/7zip/UI/Explorer/ContextMenu.cpp
+++ b/CPP/7zip/UI/Explorer/ContextMenu.cpp
@@ -408,7 +408,8 @@ static UString GetQuotedReducedString(const UString &s)
   UString s2 = s;
   ReduceString(s2);
   s2.Replace(L"&", L"&&");
-  return GetQuotedString(s2);
+  s2.InsertAtFront(L'"'); s2 += L'"'; // quote without GetQuotedString (because it escapes now)
+  return s2;
 }
 
 static void MyFormatNew_ReducedName(UString &s, const UString &name)

--- a/CPP/7zip/UI/FileManager/PanelItemOpen.cpp
+++ b/CPP/7zip/UI/FileManager/PanelItemOpen.cpp
@@ -685,9 +685,6 @@ static bool DoItemAlwaysStart(const UString &name)
   return FindExt(kStartExtensions, name);
 }
 
-UString GetQuotedString(const UString &s);
-
-
 void SplitCmdLineSmart(const UString &cmd, UString &prg, UString &params);
 void SplitCmdLineSmart(const UString &cmd, UString &prg, UString &params)
 {

--- a/CPP/Common/MyString.cpp
+++ b/CPP/Common/MyString.cpp
@@ -1206,6 +1206,16 @@ UString &UString::operator=(const UString &s)
   return *this;
 }
 
+void UString::AddFrom(const wchar_t *s, unsigned len) // no check
+{
+  if (len) {
+    Grow(len);
+    wmemcpy(_chars + _len, s, len);
+    _len += len;
+    _chars[_len] = 0;
+  }
+}
+
 void UString::SetFrom(const wchar_t *s, unsigned len) // no check
 {
   if (len > _limit)

--- a/CPP/Common/MyString.cpp
+++ b/CPP/Common/MyString.cpp
@@ -1803,3 +1803,13 @@ FString us2fs(const wchar_t *s)
 }
 
 #endif // USE_UNICODE_FSTRING
+
+// ----------------------------------------
+
+UString GetQuotedString(const UString &s)
+{
+  UString s2 ('\"');
+  s2 += s;
+  s2 += '\"';
+  return s2;
+}

--- a/CPP/Common/MyString.cpp
+++ b/CPP/Common/MyString.cpp
@@ -1806,10 +1806,44 @@ FString us2fs(const wchar_t *s)
 
 // ----------------------------------------
 
-UString GetQuotedString(const UString &s)
+UString GetQuotedString(const UString &src)
 {
   UString s2 ('\"');
-  s2 += s;
+  unsigned bcount = 0;
+  wchar_t c; const wchar_t *f = src.Ptr(), *s = f, *b = f;
+  // add string considering backslashes before quote (escape them):
+  while (1)
+  {
+    c = *s++;
+    switch (c)
+    {
+      case L'\\':
+        // a backslash - save the position and count them up to quote-char or regular char
+        if (!bcount) b = s-1;
+        bcount++;
+      break;
+      case L'\0':
+        // end of string (it is always quoted, so need to escape backslashes too):
+      case L'"':
+        // add part before backslash (and unescaped backslashes if some are there):
+        s2.AddFrom(f, (unsigned)(s - f - 1));
+        f = s;
+        if (bcount) {
+          // escape backslashes before quote (same count of BS again):
+          s2.AddFrom(b, (unsigned)(s - b - 1));
+        }
+        // done if end of string
+        if (c == L'\0') goto done;
+        // escape this quote char:
+        s2 += L"\\\"";
+      break;
+      default:
+        // a regular character, reset backslash counter
+        bcount = 0;
+    }
+  }
+  s2.AddFrom(f, (unsigned)(s - f - 1));
+done:
   s2 += '\"';
   return s2;
 }

--- a/CPP/Common/MyString.h
+++ b/CPP/Common/MyString.h
@@ -994,9 +994,6 @@ typedef const FChar *CFSTR;
 
 typedef CObjectVector<FString> FStringVector;
 
-#endif
-
-
 
 #if defined(_WIN32)
   // #include <wchar.h>
@@ -1011,4 +1008,8 @@ typedef CObjectVector<FString> FStringVector;
 // WSL scheme
 #define WCHAR_IN_FILE_NAME_BACKSLASH_REPLACEMENT  ((wchar_t)((unsigned)(0xF000) + (unsigned)'\\'))
 // #define WCHAR_IN_FILE_NAME_BACKSLASH_REPLACEMENT  '_'
+#endif
+
+UString GetQuotedString(const UString &s);
+
 #endif

--- a/CPP/Common/MyString.h
+++ b/CPP/Common/MyString.h
@@ -628,6 +628,7 @@ public:
   UString &operator=(char c) { return (*this)=((wchar_t)(unsigned char)c); }
   UString &operator=(const wchar_t *s);
   UString &operator=(const UString &s);
+  void AddFrom(const wchar_t *s, unsigned len); // no check
   void SetFrom(const wchar_t *s, unsigned len); // no check
   void SetFromBstr(LPCOLESTR s);
   UString &operator=(const char *s);

--- a/CPP/Windows/ProcessUtils.cpp
+++ b/CPP/Windows/ProcessUtils.cpp
@@ -12,16 +12,6 @@ extern bool g_IsNT;
 
 namespace NWindows {
 
-#ifndef UNDER_CE
-static UString GetQuotedString(const UString &s)
-{
-  UString s2 ('\"');
-  s2 += s;
-  s2 += '\"';
-  return s2;
-}
-#endif
-
 WRes CProcess::Create(LPCWSTR imageName, const UString &params, LPCWSTR curDir)
 {
   /*


### PR DESCRIPTION
This should fix #312 for new command-line parser algorithm (#307, #310).

Proposed PR:
* restores the fixes for "vulnerable command line parsing" (#307, #310);
  (it reverts commit d94284915adee41e04d229af657931b2f9b2a4fc, excepting version bump);
* realizes code deduplication (uniquifies the function `GetQuotedString`, moved to MyString now);
* fixes common `GetQuotedString` which uses correct windows command-line notation now (escaping of backslashes and quotes);

I did not test it from explorer integration (didn't install/register it yet), so would be nice if someone could test it...
Only tested from compiled `7zFM.exe`, for instance from its context menu where previously (without that fix) it failed with same error like in #312.
Test and review are welcome.