### PR TITLE
Add "ZS" to the file manager's name to allow for differentiation

### DIFF
--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -11,6 +11,7 @@
 
 name: Build Windows binaries
 on: [push, pull_request]
+  workflow_dispatch:
 
 
 jobs:

--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -10,7 +10,7 @@
 ########################################################################################
 
 name: Build Windows binaries
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 
 jobs:

--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -11,7 +11,6 @@
 
 name: Build Windows binaries
 on: [push, pull_request]
-  workflow_dispatch:
 
 
 jobs:

--- a/C/Util/7zipInstall/7zipInstall.c
+++ b/C/Util/7zipInstall/7zipInstall.c
@@ -803,7 +803,7 @@ static void SetShellProgramsGroup(HWND hwndOwner)
       for (k = 0; k < 2; k++)
       {
         CpyAscii(link + baseLen, k == 0 ?
-            "7-Zip File Manager.lnk" :
+            "7-Zip ZS File Manager.lnk" :
             "7-Zip Help.lnk"
            );
         wcscpy(destPath, path);

--- a/C/Util/7zipUninstall/7zipUninstall.c
+++ b/C/Util/7zipUninstall/7zipUninstall.c
@@ -366,7 +366,7 @@ static void SetShellProgramsGroup(HWND hwndOwner)
       for (k = 0; k < 2; k++)
       {
         CpyAscii(link + baseLen, k == 0 ?
-            "7-Zip File Manager.lnk" :
+            "7-Zip ZS File Manager.lnk" :
             "7-Zip Help.lnk");
         wcscpy(destPath, path);
         CatAscii(destPath, k == 0 ?

--- a/CPP/7zip/UI/FileManager/7zFM.exe.manifest
+++ b/CPP/7zip/UI/FileManager/7zFM.exe.manifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
   <assemblyIdentity version="1.0.0.0" processorArchitecture="*" name="7-Zip.7-Zip.7zFM" type="win32"/>
-  <description>7-Zip File Manager.</description>
+  <description>7-Zip ZS File Manager.</description>
   <dependency>
     <dependentAssembly><assemblyIdentity type="win32" name="Microsoft.Windows.Common-Controls" version="6.0.0.0" processorArchitecture="*" publicKeyToken="6595b64144ccf1df" language="*"/></dependentAssembly>
   </dependency>

--- a/CPP/7zip/UI/FileManager/resource.rc
+++ b/CPP/7zip/UI/FileManager/resource.rc
@@ -2,7 +2,7 @@
 #include "../../GuiCommon.rc"
 #include "resource.h"
 
-MY_VERSION_INFO_APP("7-Zip File Manager", "7zFM")
+MY_VERSION_INFO_APP("7-Zip ZS File Manager", "7zFM")
 
 IDR_ACCELERATOR1 ACCELERATORS
 BEGIN

--- a/DOC/7zip.wxs
+++ b/DOC/7zip.wxs
@@ -187,7 +187,7 @@
 
           <Component Id="Fm" Guid="$(var.CompFm)" DiskId="1" Win64="$(var.Is64)">
             <File Id="_7zFM.exe" Name="7zFM.exe">
-              <Shortcut Id="startmenuFmShortcut" Directory="PMenu" Name="7zipFM" LongName="7-Zip File Manager" />
+              <Shortcut Id="startmenuFmShortcut" Directory="PMenu" Name="7zipFM" LongName="7-Zip ZS File Manager" />
             </File>
           </Component>
 


### PR DESCRIPTION
At this moment, if you have both 7-Zip (normal) and 7-Zip ZSTD installed, it can be confusing to know which one is which
![image](https://github.com/mcmilk/7-Zip-zstd/assets/98893064/5a3a7ad9-47a7-43a6-a9c1-f46379f5825b)
With this PR, the names are different, so it's easier to know which one is which
![image](https://github.com/mcmilk/7-Zip-zstd/assets/98893064/ac98d740-e92d-4028-ab38-af969af40fb5)
This PR also changes the names used in the Start menu
![image](https://github.com/mcmilk/7-Zip-zstd/assets/98893064/5a7b0985-8ee4-4221-aedc-2dc7d9f5692f)
(To whoever decides to accept this PR, please ignore the "Update build-win.yml" commits, that was me trying to get Github Actions to work)
