### PR TITLE
Fix setting of common properties (`-mmt=n` option is ignored by many handlers)

### DIFF
--- a/CPP/7zip/Archive/Common/HandlerOut.cpp
+++ b/CPP/7zip/Archive/Common/HandlerOut.cpp
@@ -203,8 +203,9 @@ HRESULT CMultiMethodProps::SetProperty(const wchar_t *nameSpec, const PROPVARIAN
 
   {
     HRESULT hres;
-    if (SetCommonProperty(name, value, hres))
-      return hres;
+    SetCommonProperty(name, value, hres);
+    /* don't return here, since many handlers set common properties (e. g. kNumThreads)
+       with SetCoderProperties, so add it also as prop by its ID from name below */
   }
   
   UInt32 number;
@@ -258,11 +259,9 @@ HRESULT CSingleMethodProps::SetProperty(const wchar_t *name2, const PROPVARIANT 
   }
   {
     HRESULT hres;
-    if (SetCommonProperty(name, value, hres))
-    {
-      // processed = true;
-      return S_OK;
-    }
+    SetCommonProperty(name, value, hres);
+    /* don't return here, since many handlers set common properties (e. g. kNumThreads)
+       with SetCoderProperties, so add it also as prop by its ID from name below */
   }
   RINOK(ParseMethodFromPROPVARIANT(name, value));
   return S_OK;


### PR DESCRIPTION
This PR fixes setting of `-mmt=n` option for many handlers (previously ignored by zstd, brotli, lz*, etc), so adding `-mmt=1` to the call like below caused multi-threaded processing with default number of threads:
```
7z a -tzstd -mmt=1 archive.zstd large-file-to-compress.txt
```
So parallel compression of multiple files with several processes can cause unneeded context switches due to unexpected multi-threaded processing.

### Analyze

Return after call of `SetCommonProperty` (setting common properties `mt` and `memuse` to members of `CCommonMethodProps` avoid that properties gets added regularly, so many handlers setting that via `SetCoderProperties` wouldn't consider that option at all, because option doesn't exists in the props.
For example this branch was previously never reachable:
https://github.com/mcmilk/7-Zip-zstd/blob/8f52579e9e70645d93aa763342dd6f5db2b47063/CPP/7zip/Compress/ZstdEncoder.cpp#L58

Alternatively one'd rewrite it in every affected handler like in:
https://github.com/mcmilk/7-Zip-zstd/blob/8f52579e9e70645d93aa763342dd6f5db2b47063/CPP/7zip/Archive/ZstdHandler.cpp#L276
with:
```diff
 static HRESULT UpdateArchive(
     UInt64 unpackSize,
     ISequentialOutStream *outStream,
-    const CProps &props,
+    const CSingleMethodProps &props,
 ...
   RINOK(props.SetCoderProps(encoderSpec, NULL));
+  if (props._numThreads_WasForced) {
+    encoderSpec->SetNumberOfThreads(props._numThreads);
+  }
```
Just it would be not quite backwards compatible (if one remove dup processing in `SetCoderProperties` at the same time). 
As well as one should extend encoder and/or decoder of every handler, and this fix is minimalistic in opposite.
