### PR TITLE
Amend for brotli (de)compress (-mmt1), update README.md

### DIFF
--- a/CPP/7zip/Archive/ArchiveExports.cpp
+++ b/CPP/7zip/Archive/ArchiveExports.cpp
@@ -10,7 +10,7 @@
 
 #include "../Common/RegisterArc.h"
 
-static const unsigned kNumArcsMax = 64;
+static const unsigned kNumArcsMax = 72;
 static unsigned g_NumArcs = 0;
 static unsigned g_DefaultArcIndex = 0;
 static const CArcInfo *g_Arcs[kNumArcsMax];

--- a/CPP/7zip/Archive/BrotliHandler.cpp
+++ b/CPP/7zip/Archive/BrotliHandler.cpp
@@ -173,6 +173,9 @@ STDMETHODIMP CHandler::Extract(const UInt32 *indices, UInt32 numItems,
 
   NCompress::NBROTLI::CDecoder *decoderSpec = new NCompress::NBROTLI::CDecoder;
   decoderSpec->SetNumberOfThreads(0); /* .br - single threaded processing (without header/mt-frames) */
+  if (_props._numThreads_WasForced) {
+    decoderSpec->SetNumberOfThreads(_props._numThreads); // translate to decoder (important for -mmt>=2 to use brotli-mt)
+  }
   CMyComPtr<ICompressCoder> decoder = decoderSpec;
   decoderSpec->SetInStream(_seqStream);
 

--- a/CPP/7zip/Compress/BrotliDecoder.cpp
+++ b/CPP/7zip/Compress/BrotliDecoder.cpp
@@ -100,6 +100,10 @@ STDMETHODIMP CDecoder::SetNumberOfThreads(UInt32 numThreads)
   const UInt32 kNumThreadsMax = BROTLIMT_THREAD_MAX;
   if (numThreads < 0) numThreads = 0;
   if (numThreads > kNumThreadsMax) numThreads = kNumThreadsMax;
+  // if single-threaded, retain artificial number set in BrotliHandler (always prefer .br format):
+  if (_numThreads == 0 && numThreads == 1) {
+    numThreads = 0;
+  }
   _numThreads = numThreads;
   return S_OK;
 }

--- a/CPP/7zip/Compress/BrotliEncoder.cpp
+++ b/CPP/7zip/Compress/BrotliEncoder.cpp
@@ -156,6 +156,10 @@ STDMETHODIMP CEncoder::SetNumberOfThreads(UInt32 numThreads)
   const UInt32 kNumThreadsMax = BROTLIMT_THREAD_MAX;
   if (numThreads < 0) numThreads = 0;
   if (numThreads > kNumThreadsMax) numThreads = kNumThreadsMax;
+  // if single-threaded, retain artificial number set in BrotliHandler (always prefer .br format):
+  if (_numThreads == 0 && numThreads == 1) {
+    numThreads = 0;
+  }
   _numThreads = numThreads;
   return S_OK;
 }

--- a/CPP/7zip/UI/Common/LoadCodecs.cpp
+++ b/CPP/7zip/UI/Common/LoadCodecs.cpp
@@ -122,7 +122,7 @@ static bool ReadPathFromRegistry(HKEY baseKey, LPCWSTR value, FString &path)
 #endif // EXTERNAL_CODECS
 
 
-static const unsigned kNumArcsMax = 64;
+static const unsigned kNumArcsMax = 72;
 static unsigned g_NumArcs = 0;
 static const CArcInfo *g_Arcs[kNumArcsMax];
 

--- a/README.md
+++ b/README.md
@@ -114,13 +114,13 @@ Hashers:
 ### Usage and features of the full installation
 
 - compression and decompression for [Brotli], [Lizard], [LZ4], [LZ5] and [Zstandard] within the [7-Zip] container format
-- compression and decompression of [Lizard] (`.liz`), [LZ4] (`.lz4`), [LZ5] (`.lz5`) and [Zstandard] (`.zst`) files
+- compression and decompression of [Brotli] (`.br`), [Lizard] (`.liz`), [LZ4] (`.lz4`), [LZ5] (`.lz5`) and [Zstandard] (`.zst`) files
 - handling of ZIP files with [Zstandard] compression
 - included [lzip] decompression support, patch from: https://download.savannah.gnu.org/releases/lzip/7zip/
 - explorer context menu: _"Add to xy.7z"_ will use all parameters of the last "Add to Archive" compression dialog (this includes: method, level, dictionary, blocksize, threads and paramters input box)
 - squashfs files with LZ4 or Zstandard compression can be handled
 - several history settings aren't stored by default, look [here](https://sourceforge.net/p/sevenzip/discussion/45797/thread/dc2ac53d/?limit=25) for some info about that, you can restore original 7-Zip behavior via `tools->options->settings`
-- these hashes can be calculated: CRC32, CRC64, MD2, MD4, MD5, SHA1, SHA256, SHA384, SHA512, XXH32, XXH64, BLAKE2sp, BLAKE3 (lowercase or uppercase)
+- these hashes can be calculated: CRC32, CRC64, MD2, MD4, MD5, SHA1, SHA256, SHA384, SHA512, SHA3-256, SHA3-384, SHA3-512, XXH32, XXH64, BLAKE2sp, BLAKE3 (lowercase or uppercase)
 
 ```
 7z a archiv.7z -m0=zstd -mx0   Zstandard Fastest Mode, without BCJ preprocessor


### PR DESCRIPTION
The fix contains:
- if single-threaded brotli, retain artificial number set in BrotliHandler (0) - always prefer it for .br format, otherwise `-mmt1` causes that it'd use brotli-mt and the stream is incompatible; `-mmt=n` with `n >= 2` forces multi-threaded compression/decompression (therefore incompatible with standard brotli)
- translate threads to decoder (previously ignored): important for `-mmt>=2` to use brotli-mt (the streams are incompatible)
- update README.md - brotli (de)compress, new hash algorithms (amend to #330).

Amend to #351: without the fix, compression with `-mmt1` creates brotli-mt stream (incompatible with default brotli) and decompression always used single-threaded compression, so can't unpack the stream, created with `-mmt1` at all.

Now the compression and decompression are consistent and:
- without `-mmt` it is equivalent `-mmt0` but also `-mmt1` and uses single-threaded brotli for compress/decompress.
- with `-mmt=n` where `n >= 2`, it uses multi-threaded brotli (would create or extract incompatible to standard brotli stream).
