### PR TITLE
Fix memory leak in brotlimt

### DIFF
--- a/C/zstdmt/brotli-mt_compress.c
+++ b/C/zstdmt/brotli-mt_compress.c
@@ -480,6 +480,15 @@ size_t BROTLIMT_compressCCtx(BROTLIMT_CCtx * ctx, BROTLIMT_RdWr_t * rdwr)
 			retval_of_thread = p;
 	}
 
+	/* move remaining done/busy entries to free list */
+	while (!list_empty(&ctx->writelist_done)) {
+		struct list_head *entry = list_first(&ctx->writelist_done);
+		list_move(entry, &ctx->writelist_free);
+	}
+	while (!list_empty(&ctx->writelist_busy)) {
+		struct list_head* entry = list_first(&ctx->writelist_busy);
+		list_move(entry, &ctx->writelist_free);
+	}
 	/* clean up lists */
 	while (!list_empty(&ctx->writelist_free)) {
 		struct writelist *wl;

--- a/C/zstdmt/brotli-mt_decompress.c
+++ b/C/zstdmt/brotli-mt_decompress.c
@@ -363,12 +363,7 @@ static void *pt_decompress(void *arg)
 	}
 
 	/* everything is okay */
-	pthread_mutex_lock(&ctx->write_mutex);
-	list_move(&wl->node, &ctx->writelist_free);
-	pthread_mutex_unlock(&ctx->write_mutex);
-	if (in->allocated)
-		free(in->buf);
-	return 0;
+	result = 0;
 
  error_lock:
 	pthread_mutex_lock(&ctx->write_mutex);
@@ -508,8 +503,8 @@ size_t BROTLIMT_decompressDCtx(BROTLIMT_DCtx * ctx, BROTLIMT_RdWr_t * rdwr)
 		/* no pthread_create() needed! */
 		void *p = pt_decompress(w);
 		if (p)
-			return (size_t) p;
-		goto okay;
+			retval_of_thread = p;
+		goto done;
 	}
 
 	/* multi threaded */
@@ -530,7 +525,16 @@ size_t BROTLIMT_decompressDCtx(BROTLIMT_DCtx * ctx, BROTLIMT_RdWr_t * rdwr)
 			retval_of_thread = p;
 	}
 
- okay:
+ done:
+	/* move remaining done/busy entries to free list */
+	while (!list_empty(&ctx->writelist_done)) {
+		struct list_head *entry = list_first(&ctx->writelist_done);
+		list_move(entry, &ctx->writelist_free);
+	}
+	while (!list_empty(&ctx->writelist_busy)) {
+		struct list_head* entry = list_first(&ctx->writelist_busy);
+		list_move(entry, &ctx->writelist_free);
+	}
 	/* clean up the buffers */
 	while (!list_empty(&ctx->writelist_free)) {
 		struct writelist *wl;


### PR DESCRIPTION
If MT brotli compression/decompression stops unexpectedly or after canceling, for instance in error case by write, if it was cut or by partial extraction, they may leak:
- because of return that bypass cleanup (affected only extract with `-mmt1`)
- because some entries may still remain in `writelist_done` or `writelist_busy` lists and they, in contrast to `writelist_free` list, will not be freed (so leaking with `wl` but also large buffer blocks `wl->out.buf`);

This fix removes possible memory leakage in such cases.

In addition this PR has a small code deduplication (in [brotli-mt_decompress.c:366-371](https://github.com/mcmilk/7-Zip-zstd/pull/355/files#diff-194e88843f6d8ab41850caa7de9284b11c9448ec682f47f495233ac46a143e80L366-L371)).
