### PR TITLE
Fix the build of Clang 21.1.8.

### DIFF
--- a/CPP/7zip/Compress/BrotliDecoder.h
+++ b/CPP/7zip/Compress/BrotliDecoder.h
@@ -86,7 +86,7 @@ public:
 
 public:
   CDecoder();
-  virtual ~CDecoder();
+  ~CDecoder();
 };
 
 }}

--- a/CPP/7zip/Compress/LizardDecoder.h
+++ b/CPP/7zip/Compress/LizardDecoder.h
@@ -88,7 +88,7 @@ public:
 
 public:
   CDecoder();
-  virtual ~CDecoder();
+  ~CDecoder();
 };
 
 }}

--- a/CPP/7zip/Compress/Lz4Decoder.h
+++ b/CPP/7zip/Compress/Lz4Decoder.h
@@ -84,7 +84,7 @@ public:
 
 public:
   CDecoder();
-  virtual ~CDecoder();
+  ~CDecoder();
 };
 
 }}

--- a/CPP/7zip/Compress/Lz5Decoder.h
+++ b/CPP/7zip/Compress/Lz5Decoder.h
@@ -87,7 +87,7 @@ public:
 
 public:
   CDecoder();
-  virtual ~CDecoder();
+  ~CDecoder();
 };
 
 }}

--- a/CPP/7zip/Compress/ZstdDecoder.h
+++ b/CPP/7zip/Compress/ZstdDecoder.h
@@ -86,7 +86,7 @@ public:
 
 public:
   CDecoder();
-  virtual ~CDecoder();
+  ~CDecoder();
 };
 
 }}


### PR DESCRIPTION
I had to fix some errors when compiling with Clang 21.1.8 on Debian testing. Specifically, I removed the unnecessary "virtual" declarations from the some header files.