### PR TITLE
Add zstd decompression support for NSIS archives

### DIFF
--- a/CPP/7zip/Archive/Nsis/NsisDecode.cpp
+++ b/CPP/7zip/Archive/Nsis/NsisDecode.cpp
@@ -25,6 +25,8 @@ UInt64 CDecoder::GetInputProcessedSize() const
     return _deflateDecoder->GetInputProcessedSize();
   if (_bzDecoder)
     return _bzDecoder->GetInputProcessedSize();
+  if (_zstdDecoder)
+    return _zstdDecoder->GetInputProcessedSize();
   return 0;
 }
 
@@ -54,6 +56,10 @@ HRESULT CDecoder::Init(ISequentialInStream *inStream, bool &useFilter)
       case NMethodType::kLZMA:
         _lzmaDecoder = new NCompress::NLzma::CDecoder();
         _codecInStream = _lzmaDecoder;
+        break;
+      case NMethodType::kZstd:
+        _zstdDecoder = new NCompress::NZSTD::CDecoder();
+        _codecInStream = _zstdDecoder;
         break;
       default: return E_NOTIMPL;
     }

--- a/CPP/7zip/Archive/Nsis/NsisDecode.h
+++ b/CPP/7zip/Archive/Nsis/NsisDecode.h
@@ -11,6 +11,7 @@
 #include "../../Compress/BZip2Decoder.h"
 #include "../../Compress/DeflateDecoder.h"
 #include "../../Compress/LzmaDecoder.h"
+#include "../../Compress/ZstdDecoder.h"
 
 namespace NArchive {
 namespace NNsis {
@@ -22,7 +23,8 @@ namespace NMethodType
     kCopy,
     kDeflate,
     kBZip2,
-    kLZMA
+    kLZMA,
+    kZstd
   };
 }
 
@@ -42,6 +44,7 @@ class CDecoder
   NCompress::NBZip2::CNsisDecoder *_bzDecoder;
   NCompress::NDeflate::NDecoder::CCOMCoder *_deflateDecoder;
   NCompress::NLzma::CDecoder *_lzmaDecoder;
+  NCompress::NZSTD::CDecoder *_zstdDecoder;
 
 public:
   CMyComPtr<IInStream> InputStream; // for non-solid
@@ -62,6 +65,7 @@ public:
     _bzDecoder = NULL;
     _deflateDecoder = NULL;
     _lzmaDecoder = NULL;
+    _zstdDecoder = NULL;
   }
 
   void Release()
@@ -74,6 +78,7 @@ public:
     _bzDecoder = NULL;
     _deflateDecoder = NULL;
     _lzmaDecoder = NULL;
+    _zstdDecoder = NULL;
   }
 
   UInt64 GetInputProcessedSize() const;

--- a/CPP/7zip/Archive/Nsis/NsisHandler.cpp
+++ b/CPP/7zip/Archive/Nsis/NsisHandler.cpp
@@ -32,6 +32,7 @@ static const char * const kMethods[] =
   , "Deflate"
   , "BZip2"
   , "LZMA"
+  , "Zstd"
 };
 
 static const Byte kProps[] =

--- a/CPP/7zip/Archive/Nsis/NsisIn.cpp
+++ b/CPP/7zip/Archive/Nsis/NsisIn.cpp
@@ -5285,6 +5285,7 @@ HRESULT CInArchive::Parse()
       case NMethodType::kDeflate: m = "zlib"; break;
       case NMethodType::kBZip2: m = "bzip2"; break;
       case NMethodType::kLZMA: m = "lzma"; break;
+      case NMethodType::kZstd: m = "zstd"; break;
       default: break;
     }
     Script += "SetCompressor";
@@ -5750,6 +5751,11 @@ static bool IsBZip2(const Byte *p)
   return (p[0] == 0x31 && p[1] < 14);
 }
 
+static bool IsZstd(const Byte *p)
+{
+  return (p[0] == 0x28 && p[1] == 0xB5 && p[2] == 0x2F && p[3] == 0xFD);
+}
+
 HRESULT CInArchive::Open2(const Byte *sig, size_t size)
 {
   const UInt32 kSigSize = 4 + 1 + 5 + 2; // size, flag, 5 - lzma props, 2 - lzma first bytes
@@ -5799,11 +5805,15 @@ HRESULT CInArchive::Open2(const Byte *sig, size_t size)
       Method = NMethodType::kLZMA;
     else if (IsBZip2(sig + 4))
       Method = NMethodType::kBZip2;
+    else if (IsZstd(sig + 4))
+      Method = NMethodType::kZstd;
     else
       Method = NMethodType::kDeflate;
   }
   else if (IsBZip2(sig))
     Method = NMethodType::kBZip2;
+  else if (IsZstd(sig))
+    Method = NMethodType::kZstd;
   else
     Method = NMethodType::kDeflate;
 

--- a/CPP/7zip/Compress/ZstdDecoder.cpp
+++ b/CPP/7zip/Compress/ZstdDecoder.cpp
@@ -13,7 +13,9 @@ CDecoder::CDecoder():
   _srcBufSize(ZSTD_DStreamInSize()),
   _dstBufSize(ZSTD_DStreamOutSize()),
   _processedIn(0),
-  _processedOut(0)
+  _processedOut(0),
+  _readSrcPos(0),
+  _readSrcLen(0)
 {
   _props.clear();
 }
@@ -55,6 +57,8 @@ HRESULT CDecoder::SetOutStreamSizeResume(const UInt64 * /*outSize*/)
 Z7_COM7F_IMF(CDecoder::SetOutStreamSize(const UInt64 * outSize))
 {
   _processedIn = 0;
+  _readSrcPos = 0;
+  _readSrcLen = 0;
   RINOK(SetOutStreamSizeResume(outSize))
   return S_OK;
 }
@@ -185,6 +189,70 @@ Z7_COM7F_IMF(CDecoder::SetInStream(ISequentialInStream * inStream))
 Z7_COM7F_IMF(CDecoder::ReleaseInStream())
 {
   _inStream.Release();
+  return S_OK;
+}
+
+Z7_COM7F_IMF(CDecoder::Read(void *data, UInt32 size, UInt32 *processedSize))
+{
+  if (processedSize)
+    *processedSize = 0;
+
+  /* 1) create/reset context */
+  if (!_ctx) {
+    _ctx = ZSTD_createDCtx();
+    if (!_ctx)
+      return E_OUTOFMEMORY;
+    _srcBuf = MyAlloc(_srcBufSize);
+    if (!_srcBuf)
+      return E_OUTOFMEMORY;
+    _dstBuf = MyAlloc(_dstBufSize);
+    if (!_dstBuf)
+      return E_OUTOFMEMORY;
+    ZSTD_DCtx_setParameter(_ctx, ZSTD_d_windowLogMax, ZSTD_WINDOWLOG_MAX);
+    _readSrcPos = 0;
+    _readSrcLen = 0;
+  }
+
+  UInt32 totalOut = 0;
+  Byte *outPtr = (Byte *)data;
+
+  while (totalOut < size) {
+    /* refill input buffer if needed */
+    if (_readSrcPos >= _readSrcLen) {
+      _readSrcLen = _srcBufSize;
+      RINOK(ReadStream(_inStream, _srcBuf, &_readSrcLen))
+      _processedIn += _readSrcLen;
+      _readSrcPos = 0;
+      if (_readSrcLen == 0)
+        break; /* EOF */
+    }
+
+    ZSTD_inBuffer zIn;
+    zIn.src = (const Byte *)_srcBuf + _readSrcPos;
+    zIn.size = _readSrcLen - _readSrcPos;
+    zIn.pos = 0;
+
+    ZSTD_outBuffer zOut;
+    zOut.dst = outPtr + totalOut;
+    zOut.size = size - totalOut;
+    zOut.pos = 0;
+
+    size_t result = ZSTD_decompressStream(_ctx, &zOut, &zIn);
+    if (ZSTD_isError(result))
+      return E_FAIL;
+
+    _readSrcPos += zIn.pos;
+    totalOut += (UInt32)zOut.pos;
+    _processedOut += zOut.pos;
+
+    if (result == 0) {
+      /* frame complete */
+      ZSTD_DCtx_reset(_ctx, ZSTD_reset_session_only);
+    }
+  }
+
+  if (processedSize)
+    *processedSize = totalOut;
   return S_OK;
 }
 #endif

--- a/CPP/7zip/Compress/ZstdDecoder.h
+++ b/CPP/7zip/Compress/ZstdDecoder.h
@@ -89,11 +89,10 @@ public:
 public:
   Z7_IFACE_COM7_IMP(ICompressSetCoderMt)
 
-  Z7_COM7F_IMF(SetOutStreamSize(const UInt64 *outSize));
+  Z7_IFACE_COM7_IMP(ICompressSetOutStreamSize)
 #ifndef Z7_NO_READ_FROM_CODER
-  Z7_COM7F_IMF(SetInStream(ISequentialInStream *inStream));
-  Z7_COM7F_IMF(ReleaseInStream());
-  Z7_COM7F_IMF(Read(void *data, UInt32 size, UInt32 *processedSize));
+  Z7_IFACE_COM7_IMP(ICompressSetInStream)
+  Z7_IFACE_COM7_IMP(ISequentialInStream)
   UInt64 GetInputProcessedSize() const { return _processedIn; }
 #endif
 

--- a/CPP/7zip/Compress/ZstdDecoder.h
+++ b/CPP/7zip/Compress/ZstdDecoder.h
@@ -46,6 +46,11 @@ class CDecoder Z7_final:
   public ICompressCoder,
   public ICompressSetDecoderProperties2,
   public ICompressSetCoderMt,
+  public ICompressSetOutStreamSize,
+#ifndef Z7_NO_READ_FROM_CODER
+  public ICompressSetInStream,
+  public ISequentialInStream,
+#endif
   public CMyUnknownImp
 {
   CMyComPtr < ISequentialInStream > _inStream;
@@ -61,6 +66,8 @@ public:
 
   UInt64 _processedIn;
   UInt64 _processedOut;
+  size_t _readSrcPos;  // current read position in _srcBuf (for Read())
+  size_t _readSrcLen;  // valid bytes in _srcBuf (for Read())
 
   HRESULT CodeSpec(ISequentialInStream *inStream, ISequentialOutStream *outStream, ICompressProgressInfo *progress);
   HRESULT CodeResume(ISequentialOutStream * outStream, const UInt64 * outSize, ICompressProgressInfo * progress);
@@ -69,6 +76,11 @@ public:
   Z7_COM_QI_BEGIN2(ICompressCoder)
   Z7_COM_QI_ENTRY(ICompressSetDecoderProperties2)
   Z7_COM_QI_ENTRY(ICompressSetCoderMt)
+  Z7_COM_QI_ENTRY(ICompressSetOutStreamSize)
+#ifndef Z7_NO_READ_FROM_CODER
+  Z7_COM_QI_ENTRY(ICompressSetInStream)
+  Z7_COM_QI_ENTRY(ISequentialInStream)
+#endif
   Z7_COM_QI_END
   Z7_COM_ADDREF_RELEASE
 
@@ -81,6 +93,7 @@ public:
 #ifndef Z7_NO_READ_FROM_CODER
   Z7_COM7F_IMF(SetInStream(ISequentialInStream *inStream));
   Z7_COM7F_IMF(ReleaseInStream());
+  Z7_COM7F_IMF(Read(void *data, UInt32 size, UInt32 *processedSize));
   UInt64 GetInputProcessedSize() const { return _processedIn; }
 #endif
 


### PR DESCRIPTION
Add zstd magic detection to both solid and non-solid NSIS code paths in NsisIn.cpp. Add kZstd method type and wire up the existing ZstdDecoder for NSIS streaming decompression. Extend ZstdDecoder with ISequentialInStream, ICompressSetInStream, and ICompressSetOutStreamSize interfaces plus a Read() method, which the NSIS handler requires for incremental decompression.

Tested with NSIS installers built using the zstd compression option (both solid and non-solid modes).