### PR TITLE
update CI: node.js 24, windows 2025 with vs2026

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,12 +61,12 @@ jobs:
         include:
           - arch: x86
             #is_arm: false
-            runner: windows-latest
+            runner: windows-2025-vs2026
             subsys: "5.01"
             platform: "x86"
           - arch: x64
             #is_arm: false
-            runner: windows-latest
+            runner: windows-2025-vs2026
             subsys: "5.02"
             platform: "x64"
           - arch: arm64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,8 @@
 
 name: Build binaries
 on: [push, pull_request]
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
 
@@ -81,7 +83,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
 
       - name: Enable Developer Command Prompt
         uses: ilammy/msvc-dev-cmd@v1.13.0
@@ -167,7 +169,7 @@ jobs:
         cd artifact
         do-release.cmd
 
-    - uses: geekyeggo/delete-artifact@v5
+    - uses: geekyeggo/delete-artifact@v6
       with:
           name: binary-*
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,7 +172,7 @@ jobs:
         cd artifact
         do-release.cmd
 
-    - uses: geekyeggo/delete-artifact@v6
+    - uses: geekyeggo/delete-artifact@176a747ab7e287e3ff4787bf8a148716375ca118 # v6.0.0
       with:
           name: binary-*
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,15 +58,15 @@ jobs:
 
     strategy:
       matrix:
-        arch: [ amd64, amd64_x86, arm64 ]
+        arch: [ x64, x86, arm64 ]
         darkmode: [darkmode, '']
         include:
-          - arch: amd64_x86
+          - arch: x86
             #is_arm: false
             runner: windows-latest
             subsys: "5.01"
             platform: "x86"
-          - arch: amd64
+          - arch: x64
             #is_arm: false
             runner: windows-latest
             subsys: "5.02"
@@ -84,11 +84,15 @@ jobs:
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v3
-
-      - name: Enable Developer Command Prompt
-        uses: ilammy/msvc-dev-cmd@v1.13.0
         with:
-          arch: ${{ matrix.arch }}
+          msbuild-architecture: ${{ matrix.arch }}
+
+      - name: Find vcvarsall path (to init Developer Command Prompt at compile phase)
+        shell: cmd
+        run: |
+          for /f "usebackq tokens=*" %%i in (`vswhere -latest -property installationPath`) do (
+            echo VCVARSALL_PATH=%%i\VC\Auxiliary\Build\vcvarsall.bat >> %GITHUB_ENV%
+          )
 
       - name: Pre-requirements
         shell: cmd
@@ -109,6 +113,7 @@ jobs:
       - name: Compiling ${{ matrix.arch }}
         shell: cmd
         run: |
+          call "%VCVARSALL_PATH%" ${{ matrix.arch }}
           set WDIR=%cd%
           set PLATFORM=${{matrix.platform}}
           set SUBSYS=${{matrix.subsys}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,6 @@
 
 name: Build binaries
 on: [push, pull_request]
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
 


### PR DESCRIPTION
Update GHA workflow: 
- prepared to use node.js 24, bump version number of several actions, silence deprecation warning of node.js 20;
- remove `ilammy/msvc-dev-cmd` dependency (still using node.js 20 and unneeded) - select arch in `microsoft/setup-msbuild` and/or calling `vcvarsall` directly
- runner switched to windows 2025 with vs2026 (default visual studio version now)
