### PR TITLE
NtfsHandler: backport 7-Zip 26.01 ClusterSizeLog bound

### DIFF
--- a/CPP/7zip/Archive/NtfsHandler.cpp
+++ b/CPP/7zip/Archive/NtfsHandler.cpp
@@ -130,7 +130,7 @@ bool CHeader::Parse(const Byte *p)
       else
         sectorsPerClusterLog = 0x100 - v;
       ClusterSizeLog = SectorSizeLog + sectorsPerClusterLog;
-      if (ClusterSizeLog > 30)
+      if (ClusterSizeLog > 21)
         return false;
     }
   }


### PR DESCRIPTION
Backports the one-line bounds tightening landed in upstream 7-Zip 26.01 (released 2026-04-27) to keep parity with mainline on the NTFS handler's `ClusterSizeLog` cap.

## What changed upstream

7-Zip 26.01 changed `CPP/7zip/Archive/NtfsHandler.cpp:133` from:

```c
      if (ClusterSizeLog > 30)
        return false;
```

to:

```c
      if (ClusterSizeLog > 21)
        return false;
```

The reason is that `GetCuSize()` further down in the same file computes:

```c
  UInt32 GetCuSize() const { return (UInt32)1 << (BlockSizeLog + CompressionUnit); }
```

With the old cap of 30, an NTFS image specifying `ClusterSizeLog = 28..30` plus `CompressionUnit = 4` makes the shift exponent reach 32, which is undefined behaviour for a 32-bit shift in C/C++. On x86/x64 the count is masked to the low 5 bits, so `GetCuSize()` returns `1` and `_inBuf` is allocated as 1 byte before the subsequent `ReadStream_FALSE` writes up to 256 MiB into it. The new cap of 21 leaves room for the maximum CompressionUnit of 4 so the exponent stays under 32.

Upstream release notes for 26.01 mention this as a security fix.

## Patch

Single line, byte-for-byte the same as upstream 26.01:

```diff
-      if (ClusterSizeLog > 30)
+      if (ClusterSizeLog > 21)
```
