### PR TITLE
StdOutStream: backport 7-Zip 26.01 terminal escape filter

### DIFF
--- a/CPP/Common/StdOutStream.cpp
+++ b/CPP/Common/StdOutStream.cpp
@@ -93,6 +93,26 @@ void CStdOutStream::Normalize_UString_LF_Allowed(UString &s)
 }
 */
 
+static inline bool IsDangerousTerminalChar(wchar_t c)
+{
+  // return ((c <= 13 && c >= 7) || c == 0x1b);
+#if 0 && defined(WCHAR_MIN) && WCHAR_MIN < 0
+  // wchar_t is signed type in posix usually.
+  // but negative numbers are not expected in wchar_t strings.
+  // if we want to show negative characters, use the following check:
+  if (c < 0) return false; // it's not expected case
+#endif
+  if (c < 0x20) return true;
+  if (c < 0x7F) return false;
+  if (c < 0x9F + 1) return true;
+  // Unicode Bidirectional (BiDi) control characters:
+  if (c < 0x202A) return false;
+  if (c < 0x202E + 1) return true;
+  if (c < 0x2066) return false;
+  if (c < 0x2069 + 1) return true;
+  return false;
+}
+
 void CStdOutStream::Normalize_UString(UString &s)
 {
   const unsigned len = s.Len();
@@ -101,15 +121,18 @@ void CStdOutStream::Normalize_UString(UString &s)
   if (IsTerminalMode)
     for (unsigned i = 0; i < len; i++)
     {
-      const wchar_t c = d[i];
-      if ((c <= 13 && c >= 7) || c == 0x1b)
+      if (IsDangerousTerminalChar(d[i]))
         d[i] = kReplaceChar;
     }
   else
     for (unsigned i = 0; i < len; i++)
     {
       const wchar_t c = d[i];
-      if (c == '\n')
+      if (c == '\n'
+#ifdef _WIN32
+        || c == '\r'
+#endif
+        )
         d[i] = kReplaceChar;
     }
 }


### PR DESCRIPTION
Backports the terminal escape filter expansion landed in upstream 7-Zip 26.01 (released 2026-04-27) to keep parity with mainline on `CStdOutStream::Normalize_UString`.

## What changed upstream

`CPP/Common/StdOutStream.cpp` in 26.00 filtered only `\a \b \t \n \v \f \r` (`c <= 13 && c >= 7`) plus the ESC byte `0x1b` when printing strings sourced from archives (entry names, error / warning messages) to the user's terminal. 26.01 replaces that with `IsDangerousTerminalChar()` which also filters:

- all of the C0 control range `0x00..0x1F`
- DEL (`0x7F`) and the C1 control range `0x80..0x9F`, including `0x9B` which terminals treat as the 8-bit CSI start-of-escape byte
- Unicode BiDi override characters `0x202A..0x202E` (LRE/RLE/PDF/LRO/RLO) and `0x2066..0x2069` (LRI/RLI/FSI/PDI), the "Trojan Source" family

## Impact in 26.00

Archive entry names are attacker-controlled UTF-16 strings printed verbatim by `7z l` and during `7z x`. With only `c <= 13 && c >= 7` filtered, an archive can:

1. Embed BiDi override codepoints in an entry name so the displayed listing disagrees with the on-disk write target (e.g. a name printed as `safe.txt` but written as `exe.tnp`).
2. Embed `0x9B` followed by ANSI sequences to overwrite earlier terminal output (e.g. mask an error line with a fake success line).

## Patch

The hunk is byte-for-byte identical to the upstream 26.01 source. `Normalize_UString_Path` reaches the same code path through `Normalize_UString`, so callers that print paths during list/extract get the fix transparently.

## Disclosure

I am not a native English speaker. AI tooling was used to polish the prose in this PR description. The fix itself is a direct backport from upstream 7-Zip 26.01 source; no design choices were made beyond matching upstream verbatim.