### PR TITLE
UdfIn: fix OOB read in CFileId::Parse alignment padding loop

### DIFF
--- a/CPP/7zip/Archive/Udf/UdfIn.cpp
+++ b/CPP/7zip/Archive/Udf/UdfIn.cpp
@@ -501,8 +501,8 @@ size_t CFileId::Parse(const Byte *p, size_t size)
   Id.Parse(p + processed, idLen);
   processed += idLen;
   // const size_t processed2 = processed;
-  for (;(processed & 3) != 0; processed++)
-    if (p[processed] != 0)
+  for (; processed & 3; processed++)
+    if (processed >= size || p[processed])
       return 0;
   // some program can create non-standard UDF file where CrcLen doesn't include Padding data
   if ((size_t)tag.CrcLen + 16 != processed


### PR DESCRIPTION
Backports the bounds-check addition landed in upstream 7-Zip 26.01 (released 2026-04-27).

## What changed upstream

After consuming the 38-byte fixed File Identifier descriptor header plus the variable-length `impLen` and `idLen` fields, `CFileId::Parse` advances `processed` up to 3 bytes to reach the next 4-byte boundary while requiring those bytes to be zero. In 26.00 that loop reads `p[processed]` without verifying `processed < size`:

\`\`\`cpp
for (;(processed & 3) != 0; processed++)
  if (p[processed] != 0)
    return 0;
\`\`\`

26.01 short-circuits the loop with a bounds check:

\`\`\`cpp
for (; processed & 3; processed++)
  if (processed >= size || p[processed])
    return 0;
\`\`\`

## Impact in 26.00

Pre-loop, the only available bound is `size >= 38 + idLen + impLen == processed` (note: `<` not `<=` in the pre-check). When the crafted UDF File Identifier descriptor fills the buffer exactly to the fixed-plus-variable size, the alignment loop reads up to 3 bytes past the buffer end on attacker-controlled input.

## Patch

Byte-for-byte identical to the upstream 26.01 source for the loop hunk. I have intentionally kept the broader 26.01 stylistic changes in `CFileId::Parse` out of this PR to minimise review surface.

## Disclosure

I am not a native English speaker. AI tooling was used to polish the prose in this PR description. The fix itself is a direct backport from upstream 7-Zip 26.01 source; no design choices were made beyond matching upstream verbatim.