### PR TITLE
SquashfsHandler: backport 7-Zip 26.01 ReadBlock bounds-check hardening

### DIFF
--- a/CPP/7zip/Archive/SquashfsHandler.cpp
+++ b/CPP/7zip/Archive/SquashfsHandler.cpp
@@ -2125,6 +2125,8 @@ HRESULT CHandler::ReadBlock(UInt64 blockIndex, Byte *dest, size_t blockSize)
       return S_FALSE;
     const CFrag &frag = _frags[node.Frag];
     offsetInBlock = node.Offset;
+    if (offsetInBlock > _h.BlockSize)
+      return S_FALSE;
     blockOffset = frag.StartBlock;
     packBlockSize = GET_COMPRESSED_BLOCK_SIZE(frag.Size);
     compressed = IS_COMPRESSED_BLOCK(frag.Size);
@@ -2166,7 +2168,8 @@ HRESULT CHandler::ReadBlock(UInt64 blockIndex, Byte *dest, size_t blockSize)
     _cachedBlockStartPos = blockOffset;
     _cachedPackBlockSize = packBlockSize;
   }
-  if (offsetInBlock + blockSize > _cachedUnpackBlockSize)
+  if (_cachedUnpackBlockSize < offsetInBlock ||
+      _cachedUnpackBlockSize - offsetInBlock < blockSize)
     return S_FALSE;
   if (blockSize != 0)
     memcpy(dest, _cachedBlock + offsetInBlock, blockSize);


### PR DESCRIPTION
Backports two `CHandler::ReadBlock()` hardenings landed in upstream 7-Zip 26.01 (released 2026-04-27).

## What changed upstream

1. The bound just before the final `memcpy(dest, _cachedBlock + offsetInBlock, blockSize)` was

   \`\`\`cpp
   if (offsetInBlock + blockSize > _cachedUnpackBlockSize)
     return S_FALSE;
   \`\`\`

   which is overflow-prone if `offsetInBlock + blockSize` wraps a 32-bit add. 26.01 rewrites it in overflow-safe subtractive form:

   \`\`\`cpp
   if (_cachedUnpackBlockSize < offsetInBlock ||
       _cachedUnpackBlockSize - offsetInBlock < blockSize)
     return S_FALSE;
   \`\`\`

2. For fragmented file inodes, `offsetInBlock = node.Offset` is taken directly from inode metadata. 26.01 adds a sanity check `offsetInBlock <= _h.BlockSize` immediately afterwards so an inode that claims an offset beyond a block is rejected up-front.

## Impact in 26.00

A crafted SquashFS image with attacker-controlled `node.Offset` near `0xFFFFFFFF` combined with a small `blockSize` can wrap `offsetInBlock + blockSize` below `_cachedUnpackBlockSize` and pass the check, after which the `memcpy` performs a length-controlled OOB read past `_cachedBlock` and writes the bytes into the caller's `dest` buffer.

## Patch

Two small hunks, byte-for-byte identical to upstream 26.01.

## Disclosure

I am not a native English speaker. AI tooling was used to polish the prose in this PR description. The fix itself is a direct backport from upstream 7-Zip 26.01 source; no design choices were made beyond matching upstream verbatim.