### PR TITLE
ArHandler: backport 7-Zip 26.01 symbol table OOB read fix

### DIFF
--- a/CPP/7zip/Archive/ArHandler.cpp
+++ b/CPP/7zip/Archive/ArHandler.cpp
@@ -473,9 +473,11 @@ HRESULT CHandler::ParseLibSymbols(IInStream *stream, unsigned fileIndex)
       if (size - pos < tableSize || (tableSize & 7) != 0)
         continue;
       size_t namesStart = pos + tableSize;
+      if (size - namesStart < 4)
+        continue;
       const UInt32 namesSize = Get32(p.ConstData() + namesStart, be);
       namesStart += 4;
-      if (namesStart > size || namesStart + namesSize != size)
+      if (namesStart + namesSize != size)
         continue;
       
       const UInt32 numSymbols = tableSize >> 3;
@@ -509,7 +511,7 @@ HRESULT CHandler::ParseLibSymbols(IInStream *stream, unsigned fileIndex)
     
     for (UInt32 i = 0; i < numSymbols; i++)
     {
-      const UInt32 offset = GetBe32(p + 4 + i * 4);
+      const UInt32 offset = GetBe32(p + 4 + (size_t)i * 4);
       RINOK(AddFunc(offset, p, size, pos))
     }
     _type = kType_ALib;
@@ -534,11 +536,11 @@ HRESULT CHandler::ParseLibSymbols(IInStream *stream, unsigned fileIndex)
     
     for (UInt32 i = 0; i < numSymbols; i++)
     {
-      // index is 1-based. So 32-bit numSymbols field works as item[0]
-      const UInt32 index = GetUi16(p + indexStart + i * 2);
+      // index is 1-based. So 32-bit numMembers field works as item[0]
+      const UInt32 index = GetUi16(p + indexStart + (size_t)i * 2);
       if (index == 0 || index > numMembers)
         return S_FALSE;
-      const UInt32 offset = GetUi32(p + index * 4);
+      const UInt32 offset = GetUi32(p + (size_t)index * 4);
       RINOK(AddFunc(offset, p, size, pos))
     }
     _type = kType_Lib;


### PR DESCRIPTION
Backports two hardenings landed in upstream 7-Zip 26.01 (released 2026-04-27).

## What changed upstream

### 1. BSD ar symbol table: 4-byte OOB read

26.00 reads `namesSize` from `p.ConstData() + namesStart` and only validates the buffer afterwards:

\`\`\`cpp
size_t namesStart = pos + tableSize;
const UInt32 namesSize = Get32(p.ConstData() + namesStart, be);   // <-- unchecked read
namesStart += 4;
if (namesStart > size || namesStart + namesSize != size)
  continue;
\`\`\`

26.01 adds an explicit pre-check so the 4-byte read is only performed when 4 bytes are available:

\`\`\`cpp
size_t namesStart = pos + tableSize;
if (size - namesStart < 4)
  continue;
const UInt32 namesSize = Get32(p.ConstData() + namesStart, be);
namesStart += 4;
if (namesStart + namesSize != size)
  continue;
\`\`\`

### 2. GNU ar / Microsoft .lib: 32-bit index arithmetic

The symbol-table iteration uses bare `i * 4`, `i * 2`, and `index * 4` arithmetic which is performed in 32-bit and then implicitly widened on dereference. 26.01 casts the multiplicand to `(size_t)` so the math is done at pointer width on 64-bit platforms, removing the risk of wrap when `numSymbols` / `numMembers` approach 2^30.

## Patch

Three small hunks, byte-for-byte identical to upstream 26.01.

## Disclosure

I am not a native English speaker. AI tooling was used to polish the prose in this PR description. The fix itself is a direct backport from upstream 7-Zip 26.01 source; no design choices were made beyond matching upstream verbatim.