### PR TITLE
AvbHandler: backport 7-Zip 26.01 hashtree length overflow fix

### DIFF
--- a/CPP/7zip/Archive/AvbHandler.cpp
+++ b/CPP/7zip/Archive/AvbHandler.cpp
@@ -408,19 +408,19 @@ HRESULT CHandler::Open2(IInStream *stream)
         ht.Parse(buf + offset);
         unsigned pos = k_Hashtree_Size_Min;
 
-        if (pos + ht.partition_name_len > descSize)
+        if (ht.partition_name_len > descSize - pos)
           return S_FALSE;
         Name.Empty(); // UTF-8
         AddNameToString(Name, buf + offset + pos, ht.partition_name_len, false);
         pos += ht.partition_name_len;
-        
-        if (pos + ht.salt_len > descSize)
+
+        if (ht.salt_len > descSize - pos)
           return S_FALSE;
         CByteBuffer salt;
         salt.CopyFrom(buf + offset + pos, ht.salt_len);
         pos += ht.salt_len;
-        
-        if (pos + ht.root_digest_len > descSize)
+
+        if (ht.root_digest_len > descSize - pos)
           return S_FALSE;
         CByteBuffer digest;
         digest.CopyFrom(buf + offset + pos, ht.root_digest_len);
@@ -434,7 +434,7 @@ HRESULT CHandler::Open2(IInStream *stream)
         AvbPropertyDescriptor pt;
         pt.Parse(buf + offset);
         unsigned pos = k_PropertyDescriptor_Size_Min;
-        
+
         if (pt.key_num_bytes > descSize - pos - 1)
           return S_FALSE;
         AString key; // UTF-8


### PR DESCRIPTION
Backports the descriptor-length bounds rewrites landed in upstream 7-Zip 26.01 (released 2026-04-27).

## What changed upstream

The three length checks in the AVB hashtree descriptor parser were rewritten from additive form to subtractive form:

```diff
- if (pos + ht.partition_name_len > descSize)
+ if (ht.partition_name_len > descSize - pos)
    return S_FALSE;
```

(also applied to `ht.salt_len` and `ht.root_digest_len`).

## Impact in 26.00

The additive form is overflow-prone: with attacker-controlled UInt32 length fields, `pos + ht.partition_name_len` can wrap past 2^32 and land below `descSize`, passing the check. The subsequent `AddNameToString(... buf + offset + pos, partition_name_len, ...)` or `salt.CopyFrom(buf + offset + pos, salt_len)` then performs a length-controlled out-of-bounds read past the descriptor buffer.

The subtractive form requires `pos <= descSize` as a precondition (established by the prior `if (descSize < k_Hashtree_Size_Min)` and subsequent `pos += ...` updates) and is robust to overflow.

## Patch

Three small hunks for the active AVB_DESCRIPTOR_TAG_HASHTREE path, byte-for-byte matching upstream 26.01. The AVB_DESCRIPTOR_TAG_PROPERTY checks already use subtractive form and are unchanged.

## Disclosure

I am not a native English speaker. AI tooling was used to polish the prose in this PR description. The fix itself is a direct backport from upstream 7-Zip 26.01 source; no design choices were made beyond matching upstream verbatim.