### PR TITLE
Register real magic bytes as lz4/lz5/lizard/zstd signatures

### DIFF
--- a/CPP/7zip/Archive/LizardHandler.cpp
+++ b/CPP/7zip/Archive/LizardHandler.cpp
@@ -339,13 +339,16 @@ Z7_COM7F_IMF(CHandler::SetProperties(const wchar_t * const *names, const PROPVAR
   return _props.SetProperties(names, values, numProps);
 }
 
-static const Byte k_Signature[] = "0x184D2206";
+// lizard frame magic, and zstdmt skippable-frame magic used for -mmt output
+static const Byte k_Signature[] = {
+    4, 0x06, 0x22, 0x4D, 0x18,
+    4, 0x50, 0x2A, 0x4D, 0x18 };
 
 REGISTER_ARC_IO(
   "lizard", "liz tliz", "* .tar", 0x11,
   k_Signature,
   0,
-  NArcInfoFlags::kKeepName,
+  NArcInfoFlags::kKeepName | NArcInfoFlags::kMultiSignature,
   0,
   IsArc_lizard)
 

--- a/CPP/7zip/Archive/Lz4Handler.cpp
+++ b/CPP/7zip/Archive/Lz4Handler.cpp
@@ -339,13 +339,16 @@ Z7_COM7F_IMF(CHandler::SetProperties(const wchar_t * const *names, const PROPVAR
   return _props.SetProperties(names, values, numProps);
 }
 
-static const Byte k_Signature[] = "0x184D2204";
+// lz4 frame magic, and zstdmt skippable-frame magic used for -mmt output
+static const Byte k_Signature[] = {
+    4, 0x04, 0x22, 0x4D, 0x18,
+    4, 0x50, 0x2A, 0x4D, 0x18 };
 
 REGISTER_ARC_IO(
   "lz4", "lz4 tlz4", "* .tar", 0x0f,
   k_Signature,
   0,
-  NArcInfoFlags::kKeepName,
+  NArcInfoFlags::kKeepName | NArcInfoFlags::kMultiSignature,
   0,
   IsArc_lz4)
 

--- a/CPP/7zip/Archive/Lz5Handler.cpp
+++ b/CPP/7zip/Archive/Lz5Handler.cpp
@@ -339,13 +339,16 @@ Z7_COM7F_IMF(CHandler::SetProperties(const wchar_t * const *names, const PROPVAR
   return _props.SetProperties(names, values, numProps);
 }
 
-static const Byte k_Signature[] = "0x184D2205";
+// lz5 frame magic, and zstdmt skippable-frame magic used for -mmt output
+static const Byte k_Signature[] = {
+    4, 0x05, 0x22, 0x4D, 0x18,
+    4, 0x50, 0x2A, 0x4D, 0x18 };
 
 REGISTER_ARC_IO(
   "lz5", "lz5 tlz5", "* .tar", 0x10,
   k_Signature,
   0,
-  NArcInfoFlags::kKeepName,
+  NArcInfoFlags::kKeepName | NArcInfoFlags::kMultiSignature,
   0,
   IsArc_lz5)
 

--- a/CPP/7zip/Archive/ZstdHandler.cpp
+++ b/CPP/7zip/Archive/ZstdHandler.cpp
@@ -354,13 +354,26 @@ Z7_COM7F_IMF(CHandler::SetProperties(const wchar_t * const *names, const PROPVAR
   return _props.SetProperties(names, values, numProps);
 }
 
-static const Byte k_Signature[] = "0xFD2FB522..28";
+// zstd frame magic (1.x), plus legacy zstd frame magics (0.1, 0.2 .. 0.8) when
+// built with ZSTD_LEGACY_SUPPORT, and the zstdmt skippable-frame magic
+static const Byte k_Signature[] = {
+    4, 0x28, 0xB5, 0x2F, 0xFD,
+#ifdef ZSTD_LEGACY_SUPPORT
+    4, 0x1E, 0xB5, 0x2F, 0xFD,
+    4, 0x22, 0xB5, 0x2F, 0xFD,
+    4, 0x23, 0xB5, 0x2F, 0xFD,
+    4, 0x24, 0xB5, 0x2F, 0xFD,
+    4, 0x25, 0xB5, 0x2F, 0xFD,
+    4, 0x26, 0xB5, 0x2F, 0xFD,
+    4, 0x27, 0xB5, 0x2F, 0xFD,
+#endif
+    4, 0x50, 0x2A, 0x4D, 0x18 };
 
 REGISTER_ARC_IO(
   "zstd", "zst zstd tzst tzstd", "* * .tar .tar", 0x0e,
   k_Signature,
   0,
-  NArcInfoFlags::kKeepName,
+  NArcInfoFlags::kKeepName | NArcInfoFlags::kMultiSignature,
   0,
   IsArc_zstd)
 


### PR DESCRIPTION
Fixes #530.

`k_Signature` in these four handlers was a string literal of the hex *text*, so `REGISTER_ARC_IO` registered ASCII characters instead of magic bytes. Details in the issue. `IsArcFunc` masks this for archive opening; what this fixes is the registered metadata, visible in `7z i`.

### Fix

Each `k_Signature` becomes a multi-signature byte array (length byte + bytes, same encoding as CpioHandler.cpp:1098-1107) with `kMultiSignature` set:

- lz4 / lz5 / lizard: the frame magic, plus the zstdmt skippable-frame magic `50 2A 4D 18` that `-mmt` output is prefixed with (C/zstdmt/lz4-mt_compress.c:299-305).
- zstd: `28 B5 2F FD`, plus the legacy 0.1 and 0.2..0.8 magics under the existing `ZSTD_LEGACY_SUPPORT` guard — mirroring `IsArc_zstd`'s own conditional (ZstdHandler.cpp:100-112) — plus the skippable magic that `IsArc_zstd` also accepts.

`BrotliHandler.cpp` is left alone: it deliberately registers `0, NULL` with `kByExtOnlyOpen`.

### Testing

Built from this branch (x64, `Format7zF` + `UI/Console`), clean rebuild, 0 errors, 0 warnings.

`7z i`, before → after:

```
lz4   0 x 1 8 4 D 2 2 0 4 00   →   04 " M 18  ||  P * M 18
```

zstd now lists all 9 signatures. Regression run over 16 combinations (lz4/lz5/lizard/zstd × `-mmt1`/`-mmt4` × 1 KB/24 MB input):

- 32/32 `7z l` report the correct `Type =`
- 32/32 `7z t` pass
- 16/16 SHA-256 match after extraction
- renaming to `.bin` still detected (no regression against the pre-patch build)
- `.xz`, `.gz`, `.7z`, `.zip`, `.tar` still report the same `Type =` as before, so the new signatures do not steal other formats
