### PR TITLE
Free the MT decompression context before error returns

### DIFF
--- a/CPP/7zip/Compress/BrotliDecoder.cpp
+++ b/CPP/7zip/Compress/BrotliDecoder.cpp
@@ -151,14 +151,16 @@ HRESULT CDecoder::CodeSpec(ISequentialInStream * inStream,
 
   /* 3) decompress */
   result = BROTLIMT_decompressDCtx(ctx, &rdwr);
+
+  /* 4) free resources */
+  BROTLIMT_freeDCtx(ctx);
+
   if (BROTLIMT_isError(result)) {
     if (result == (size_t)-BROTLIMT_error_canceled)
       return E_ABORT;
     return E_FAIL;
   }
 
-  /* 4) free resources */
-  BROTLIMT_freeDCtx(ctx);
   return res;
 }
 

--- a/CPP/7zip/Compress/LizardDecoder.cpp
+++ b/CPP/7zip/Compress/LizardDecoder.cpp
@@ -146,14 +146,16 @@ HRESULT CDecoder::CodeSpec(ISequentialInStream * inStream,
 
   /* 3) decompress */
   result = LIZARDMT_decompressDCtx(ctx, &rdwr);
+
+  /* 4) free resources */
+  LIZARDMT_freeDCtx(ctx);
+
   if (LIZARDMT_isError(result)) {
     if (result == (size_t)-LIZARDMT_error_canceled)
       return E_ABORT;
     return E_FAIL;
   }
 
-  /* 4) free resources */
-  LIZARDMT_freeDCtx(ctx);
   return res;
 }
 

--- a/CPP/7zip/Compress/Lz4Decoder.cpp
+++ b/CPP/7zip/Compress/Lz4Decoder.cpp
@@ -146,14 +146,16 @@ HRESULT CDecoder::CodeSpec(ISequentialInStream * inStream,
 
   /* 3) decompress */
   result = LZ4MT_decompressDCtx(ctx, &rdwr);
+
+  /* 4) free resources */
+  LZ4MT_freeDCtx(ctx);
+
   if (LZ4MT_isError(result)) {
     if (result == (size_t)-LZ4MT_error_canceled)
       return E_ABORT;
     return E_FAIL;
   }
 
-  /* 4) free resources */
-  LZ4MT_freeDCtx(ctx);
   return res;
 }
 

--- a/CPP/7zip/Compress/Lz5Decoder.cpp
+++ b/CPP/7zip/Compress/Lz5Decoder.cpp
@@ -146,14 +146,16 @@ HRESULT CDecoder::CodeSpec(ISequentialInStream * inStream,
 
   /* 3) decompress */
   result = LZ5MT_decompressDCtx(ctx, &rdwr);
+
+  /* 4) free resources */
+  LZ5MT_freeDCtx(ctx);
+
   if (LZ5MT_isError(result)) {
     if (result == (size_t)-LZ5MT_error_canceled)
       return E_ABORT;
     return E_FAIL;
   }
 
-  /* 4) free resources */
-  LZ5MT_freeDCtx(ctx);
   return res;
 }
 


### PR DESCRIPTION
Fixes #531.

### Fix

Move `*MT_freeDCtx(ctx)` up, to right after `*MT_decompressDCtx()` and before the `isError` check, so the context is released regardless of the outcome. `*MT_isError()` only inspects the returned `size_t` and never touches `ctx`, so the reordering is safe:

```diff
   result = LZ4MT_decompressDCtx(ctx, &rdwr);
+
+  /* 4) free resources */
+  LZ4MT_freeDCtx(ctx);
   if (LZ4MT_isError(result)) {
     if (result == (size_t)-LZ4MT_error_canceled)
       return E_ABORT;
     return E_FAIL;
   }
-
-  /* 4) free resources */
-  LZ4MT_freeDCtx(ctx);
   return res;
```

Applied identically to all four decoders.

### Testing

Built x64, 0 errors, 0 warnings.

- Leak, measured in-process with CRT debug heap (`_CrtMemCheckpoint` / `_CrtMemDifference`) against a test program linking the real `C/zstdmt` + `C/lz4` sources, lz4 as the sample: **200 iterations → 113,600 bytes before, 0 bytes after.** The other three codecs are line-for-line identical in this function and were verified by inspection, not measured separately.
- Error paths still behave: 32 combinations of truncated / bit-flipped archives, no crash, no hang, correct non-zero exit. (2 of the 32 are not detected as damaged — reproduced identically on an unpatched build, so that is pre-existing and unrelated to this change.)
- Round-trip regression for lz4/lz5/lizard with `-mmt1` and `-mmt4`, including a 25 MB input that produces 6–8 chunks: SHA-256 matches throughout.
