### PR TITLE
zstdmt: apply the brotli writelist cleanup fix to lz4, lz5 and lizard

### DIFF
--- a/C/zstdmt/lizard-mt_compress.c
+++ b/C/zstdmt/lizard-mt_compress.c
@@ -338,6 +338,15 @@ size_t LIZARDMT_compressCCtx(LIZARDMT_CCtx * ctx, LIZARDMT_RdWr_t * rdwr)
 			retval_of_thread = p;
 	}
 
+	/* move remaining done/busy entries to free list */
+	while (!list_empty(&ctx->writelist_done)) {
+		struct list_head *entry = list_first(&ctx->writelist_done);
+		list_move(entry, &ctx->writelist_free);
+	}
+	while (!list_empty(&ctx->writelist_busy)) {
+		struct list_head* entry = list_first(&ctx->writelist_busy);
+		list_move(entry, &ctx->writelist_free);
+	}
 	/* clean up lists */
 	while (!list_empty(&ctx->writelist_free)) {
 		struct writelist *wl;

--- a/C/zstdmt/lizard-mt_decompress.c
+++ b/C/zstdmt/lizard-mt_decompress.c
@@ -533,7 +533,7 @@ size_t LIZARDMT_decompressDCtx(LIZARDMT_DCtx * ctx, LIZARDMT_RdWr_t * rdwr)
 		/* no pthread_create() needed! */
 		void *p = pt_decompress(w);
 		if (p)
-			return (size_t) p;
+			retval_of_thread = p;
 		goto okay;
 	}
 
@@ -556,6 +556,15 @@ size_t LIZARDMT_decompressDCtx(LIZARDMT_DCtx * ctx, LIZARDMT_RdWr_t * rdwr)
 	}
 
  okay:
+	/* move remaining done/busy entries to free list */
+	while (!list_empty(&ctx->writelist_done)) {
+		struct list_head *entry = list_first(&ctx->writelist_done);
+		list_move(entry, &ctx->writelist_free);
+	}
+	while (!list_empty(&ctx->writelist_busy)) {
+		struct list_head* entry = list_first(&ctx->writelist_busy);
+		list_move(entry, &ctx->writelist_free);
+	}
 	/* clean up the buffers */
 	while (!list_empty(&ctx->writelist_free)) {
 		struct writelist *wl;

--- a/C/zstdmt/lz4-mt_compress.c
+++ b/C/zstdmt/lz4-mt_compress.c
@@ -364,6 +364,15 @@ size_t LZ4MT_compressCCtx(LZ4MT_CCtx * ctx, LZ4MT_RdWr_t * rdwr)
 			retval_of_thread = p;
 	}
 
+	/* move remaining done/busy entries to free list */
+	while (!list_empty(&ctx->writelist_done)) {
+		struct list_head *entry = list_first(&ctx->writelist_done);
+		list_move(entry, &ctx->writelist_free);
+	}
+	while (!list_empty(&ctx->writelist_busy)) {
+		struct list_head* entry = list_first(&ctx->writelist_busy);
+		list_move(entry, &ctx->writelist_free);
+	}
 	/* clean up lists */
 	while (!list_empty(&ctx->writelist_free)) {
 		struct writelist *wl;

--- a/C/zstdmt/lz4-mt_decompress.c
+++ b/C/zstdmt/lz4-mt_decompress.c
@@ -532,7 +532,7 @@ size_t LZ4MT_decompressDCtx(LZ4MT_DCtx * ctx, LZ4MT_RdWr_t * rdwr)
 		/* no pthread_create() needed! */
 		void *p = pt_decompress(w);
 		if (p)
-			return (size_t) p;
+			retval_of_thread = p;
 		goto okay;
 	}
 
@@ -555,6 +555,15 @@ size_t LZ4MT_decompressDCtx(LZ4MT_DCtx * ctx, LZ4MT_RdWr_t * rdwr)
 	}
 
  okay:
+	/* move remaining done/busy entries to free list */
+	while (!list_empty(&ctx->writelist_done)) {
+		struct list_head *entry = list_first(&ctx->writelist_done);
+		list_move(entry, &ctx->writelist_free);
+	}
+	while (!list_empty(&ctx->writelist_busy)) {
+		struct list_head* entry = list_first(&ctx->writelist_busy);
+		list_move(entry, &ctx->writelist_free);
+	}
 	/* clean up the buffers */
 	while (!list_empty(&ctx->writelist_free)) {
 		struct writelist *wl;

--- a/C/zstdmt/lz5-mt_compress.c
+++ b/C/zstdmt/lz5-mt_compress.c
@@ -338,6 +338,15 @@ size_t LZ5MT_compressCCtx(LZ5MT_CCtx * ctx, LZ5MT_RdWr_t * rdwr)
 			retval_of_thread = p;
 	}
 
+	/* move remaining done/busy entries to free list */
+	while (!list_empty(&ctx->writelist_done)) {
+		struct list_head *entry = list_first(&ctx->writelist_done);
+		list_move(entry, &ctx->writelist_free);
+	}
+	while (!list_empty(&ctx->writelist_busy)) {
+		struct list_head* entry = list_first(&ctx->writelist_busy);
+		list_move(entry, &ctx->writelist_free);
+	}
 	/* clean up lists */
 	while (!list_empty(&ctx->writelist_free)) {
 		struct writelist *wl;

--- a/C/zstdmt/lz5-mt_decompress.c
+++ b/C/zstdmt/lz5-mt_decompress.c
@@ -532,7 +532,7 @@ size_t LZ5MT_decompressDCtx(LZ5MT_DCtx * ctx, LZ5MT_RdWr_t * rdwr)
 		/* no pthread_create() needed! */
 		void *p = pt_decompress(w);
 		if (p)
-			return (size_t) p;
+			retval_of_thread = p;
 		goto okay;
 	}
 
@@ -555,6 +555,15 @@ size_t LZ5MT_decompressDCtx(LZ5MT_DCtx * ctx, LZ5MT_RdWr_t * rdwr)
 	}
 
  okay:
+	/* move remaining done/busy entries to free list */
+	while (!list_empty(&ctx->writelist_done)) {
+		struct list_head *entry = list_first(&ctx->writelist_done);
+		list_move(entry, &ctx->writelist_free);
+	}
+	while (!list_empty(&ctx->writelist_busy)) {
+		struct list_head* entry = list_first(&ctx->writelist_busy);
+		list_move(entry, &ctx->writelist_free);
+	}
 	/* clean up the buffers */
 	while (!list_empty(&ctx->writelist_free)) {
 		struct writelist *wl;


### PR DESCRIPTION
Fixes #532.

Carries 396505c7 (#355) over to the three codecs that were left out. Both changes mirror the brotli version:

- `*MT_decompressDCtx()`: the `threads == 1` shortcut assigns `retval_of_thread` and falls through to the cleanup label instead of returning early.
- `*MT_decompressDCtx()` and `*MT_compressCCtx()`: sweep `writelist_done` and `writelist_busy` back onto `writelist_free` right before the existing free loop.

The existing `okay:` label is kept rather than renamed to brotli's `done:`, to keep the diff minimal. No new pattern is introduced.

### Testing

Built x64, 0 errors, 0 warnings.

- Leak, measured in-process with CRT debug heap against a test program linking the real `C/zstdmt` + `C/lz4` sources (lz4 decompress, `threads == 1` error path): **100 iterations → 6,558,400 bytes before, 0 after.** lz5 / lizard and the compress-side sweep are line-for-line identical and were verified by inspection, not measured separately.
- Error paths still behave: 24 combinations of truncated / bit-flipped input, no crash, no hang, correct non-zero exit. (2 of the 24 are not reported as damaged — same on an unpatched build, so pre-existing.)
- Round-trip regression with `-mmt1` and `-mmt4` including a 25 MB input: SHA-256 matches.
