### PR TITLE
Free the worker input buffer on the early-return paths of pt_compress()

### DIFF
--- a/C/zstdmt/brotli-mt_compress.c
+++ b/C/zstdmt/brotli-mt_compress.c
@@ -239,6 +239,7 @@ static void *pt_compress(void *arg)
 			    malloc(sizeof(struct writelist));
 			if (!wl) {
 				pthread_mutex_unlock(&ctx->write_mutex);
+				free(in.buf);
 				return (void *)MT_ERROR(memory_allocation);
 			}
 			wl->out.size =
@@ -246,6 +247,7 @@ static void *pt_compress(void *arg)
 			wl->out.buf = malloc(wl->out.size);
 			if (!wl->out.buf) {
 				pthread_mutex_unlock(&ctx->write_mutex);
+				free(in.buf);
 				return (void *)MT_ERROR(memory_allocation);
 			}
 			list_add(&wl->node, &ctx->writelist_busy);
@@ -258,6 +260,7 @@ static void *pt_compress(void *arg)
 		rv = ctx->fn_read(ctx->arg_read, &in);
 		if (rv != 0) {
 			pthread_mutex_unlock(&ctx->read_mutex);
+			free(in.buf);
 			return (void *)mt_error(rv);
 		}
 
@@ -292,6 +295,7 @@ static void *pt_compress(void *arg)
 				pthread_mutex_lock(&ctx->write_mutex);
 				list_move(&wl->node, &ctx->writelist_free);
 				pthread_mutex_unlock(&ctx->write_mutex);
+				free(in.buf);
 				return (void *)MT_ERROR(frame_compress);
 			}
 		}
@@ -324,8 +328,10 @@ static void *pt_compress(void *arg)
 		pthread_mutex_lock(&ctx->write_mutex);
 		result = pt_write(ctx, wl);
 		pthread_mutex_unlock(&ctx->write_mutex);
-		if (BROTLIMT_isError(result))
+		if (BROTLIMT_isError(result)) {
+			free(in.buf);
 			return (void *)result;
+		}
 	}
 
  okay:

--- a/C/zstdmt/lizard-mt_compress.c
+++ b/C/zstdmt/lizard-mt_compress.c
@@ -238,6 +238,7 @@ static void *pt_compress(void *arg)
 			    malloc(sizeof(struct writelist));
 			if (!wl) {
 				pthread_mutex_unlock(&ctx->write_mutex);
+				free(in.buf);
 				return (void *)ERROR(memory_allocation);
 			}
 			wl->out.size =
@@ -246,6 +247,7 @@ static void *pt_compress(void *arg)
 			wl->out.buf = malloc(wl->out.size);
 			if (!wl->out.buf) {
 				pthread_mutex_unlock(&ctx->write_mutex);
+				free(in.buf);
 				return (void *)ERROR(memory_allocation);
 			}
 			list_add(&wl->node, &ctx->writelist_busy);
@@ -258,6 +260,7 @@ static void *pt_compress(void *arg)
 		rv = ctx->fn_read(ctx->arg_read, &in);
 		if (rv != 0) {
 			pthread_mutex_unlock(&ctx->read_mutex);
+			free(in.buf);
 			return (void *)mt_error(rv);
 		}
 
@@ -287,6 +290,7 @@ static void *pt_compress(void *arg)
 			pthread_mutex_unlock(&ctx->write_mutex);
 			/* user can lookup that code */
 			lizardmt_errcode = result;
+			free(in.buf);
 			return (void *)ERROR(compression_library);
 		}
 
@@ -301,8 +305,10 @@ static void *pt_compress(void *arg)
 		pthread_mutex_lock(&ctx->write_mutex);
 		result = pt_write(ctx, wl);
 		pthread_mutex_unlock(&ctx->write_mutex);
-		if (LIZARDMT_isError(result))
+		if (LIZARDMT_isError(result)) {
+			free(in.buf);
 			return (void *)result;
+		}
 	}
 
  okay:

--- a/C/zstdmt/lz4-mt_compress.c
+++ b/C/zstdmt/lz4-mt_compress.c
@@ -240,6 +240,7 @@ static void *pt_compress(void *arg)
 			    malloc(sizeof(struct writelist));
 			if (!wl) {
 				pthread_mutex_unlock(&ctx->write_mutex);
+				free(in.buf);
 				return (void *)ERROR(memory_allocation);
 			}
 			wl->out.size =
@@ -248,6 +249,7 @@ static void *pt_compress(void *arg)
 			wl->out.buf = malloc(wl->out.size);
 			if (!wl->out.buf) {
 				pthread_mutex_unlock(&ctx->write_mutex);
+				free(in.buf);
 				return (void *)ERROR(memory_allocation);
 			}
 			list_add(&wl->node, &ctx->writelist_busy);
@@ -260,6 +262,7 @@ static void *pt_compress(void *arg)
 		rv = ctx->fn_read(ctx->arg_read, &in);
 		if (rv != 0) {
 			pthread_mutex_unlock(&ctx->read_mutex);
+			free(in.buf);
 			return (void *)mt_error(rv);
 		}
 
@@ -293,6 +296,7 @@ static void *pt_compress(void *arg)
 
 				/* user can lookup that code */
 				lz4mt_errcode = result;
+				free(in.buf);
 				return (void *)ERROR(compression_library);
 			}
 
@@ -317,6 +321,7 @@ static void *pt_compress(void *arg)
 
 				/* user can lookup that code */
 				lz4mt_errcode = result;
+				free(in.buf);
 				return (void *)ERROR(compression_library);
 			}
 
@@ -327,8 +332,10 @@ static void *pt_compress(void *arg)
 		pthread_mutex_lock(&ctx->write_mutex);
 		result = pt_write(ctx, wl);
 		pthread_mutex_unlock(&ctx->write_mutex);
-		if (LZ4MT_isError(result))
+		if (LZ4MT_isError(result)) {
+			free(in.buf);
 			return (void *)result;
+		}
 	}
 
  okay:

--- a/C/zstdmt/lz5-mt_compress.c
+++ b/C/zstdmt/lz5-mt_compress.c
@@ -238,6 +238,7 @@ static void *pt_compress(void *arg)
 			    malloc(sizeof(struct writelist));
 			if (!wl) {
 				pthread_mutex_unlock(&ctx->write_mutex);
+				free(in.buf);
 				return (void *)ERROR(memory_allocation);
 			}
 			wl->out.size =
@@ -246,6 +247,7 @@ static void *pt_compress(void *arg)
 			wl->out.buf = malloc(wl->out.size);
 			if (!wl->out.buf) {
 				pthread_mutex_unlock(&ctx->write_mutex);
+				free(in.buf);
 				return (void *)ERROR(memory_allocation);
 			}
 			list_add(&wl->node, &ctx->writelist_busy);
@@ -258,6 +260,7 @@ static void *pt_compress(void *arg)
 		rv = ctx->fn_read(ctx->arg_read, &in);
 		if (rv != 0) {
 			pthread_mutex_unlock(&ctx->read_mutex);
+			free(in.buf);
 			return (void *)mt_error(rv);
 		}
 
@@ -287,6 +290,7 @@ static void *pt_compress(void *arg)
 			pthread_mutex_unlock(&ctx->write_mutex);
 			/* user can lookup that code */
 			lz5mt_errcode = result;
+			free(in.buf);
 			return (void *)ERROR(compression_library);
 		}
 
@@ -301,8 +305,10 @@ static void *pt_compress(void *arg)
 		pthread_mutex_lock(&ctx->write_mutex);
 		result = pt_write(ctx, wl);
 		pthread_mutex_unlock(&ctx->write_mutex);
-		if (LZ5MT_isError(result))
+		if (LZ5MT_isError(result)) {
+			free(in.buf);
 			return (void *)result;
+		}
 	}
 
  okay:


### PR DESCRIPTION
Fixes #536.

Adds the missing `free(in.buf)` before each early `return` in `pt_compress()`, in all four codecs.

One of them needed a brace: the `pt_write()` failure check was a braceless single statement, so adding a line before the `return` would have detached it from the `if` and made the return unconditional:

```diff
-		if (LZ4MT_isError(result))
+		if (LZ4MT_isError(result)) {
+			free(in.buf);
 			return (void *)result;
+		}
```

### Not addressed here

On the `wl->out.buf` OOM path the freshly allocated `wl` has not been added to any list yet, so it leaks too. That is a different allocation and only reachable under OOM, so I left it out of this change rather than widen the diff — happy to fold it in if you prefer.

### Testing

Built x64, 0 errors, 0 warnings.

- Leak, measured in-process with CRT debug heap against a test program linking the real sources (lz4): **500 iterations → 32,768,000 bytes before, 0 after**, for both the `fn_read`-failure and the `pt_write`-failure path. A 5-frame normal run leaks nothing and confirms the repaired `if` is still conditional (all 500 iterations perform the full 6 reads).
- Round trip for all four codecs, `-mmt1` and `-mmt4`, 1 KiB and 30 MiB inputs: 16/16 SHA-256 match. The 30 MiB `-mmt4` case is what would have caught the brace mistake.
- 16/16 truncated / bit-flipped inputs still report errors, no hang, no crash.
- lz5 / lizard / brotli are line-for-line identical here and were verified by inspection, not measured separately.
