### PR TITLE
Detect truncated input in st_decompress() for lz4, lz5 and lizard

### DIFF
--- a/C/zstdmt/lizard-mt_decompress.c
+++ b/C/zstdmt/lizard-mt_decompress.c
@@ -480,6 +480,13 @@ static size_t st_decompress(void *arg)
 		}
 	}
 
+	/* input ended, but current frame is not fully decoded yet */
+	if (nextToLoad != 0) {
+		free(out->buf);
+		free(in->buf);
+		return ERROR(frame_decompress);
+	}
+
 	/* no error */
 	free(out->buf);
 	free(in->buf);

--- a/C/zstdmt/lz4-mt_decompress.c
+++ b/C/zstdmt/lz4-mt_decompress.c
@@ -479,6 +479,13 @@ static size_t st_decompress(void *arg)
 			break;
 	}
 
+	/* input ended, but current frame is not fully decoded yet */
+	if (result != 0) {
+		free(out->buf);
+		free(in->buf);
+		return ERROR(frame_decompress);
+	}
+
 	/* no error */
 	free(out->buf);
 	free(in->buf);

--- a/C/zstdmt/lz5-mt_decompress.c
+++ b/C/zstdmt/lz5-mt_decompress.c
@@ -479,6 +479,13 @@ static size_t st_decompress(void *arg)
 		}
 	}
 
+	/* input ended, but current frame is not fully decoded yet */
+	if (nextToLoad != 0) {
+		free(out->buf);
+		free(in->buf);
+		return ERROR(frame_decompress);
+	}
+
 	/* no error */
 	free(out->buf);
 	free(in->buf);


### PR DESCRIPTION
Fixes #537.

Adds the frame-completion check that `brotli-mt_decompress.c:442` already performs, to the three siblings that lack it:

```diff
 		if (in->size == 0)
 			break;
 	}
 
+	/* input ended, but current frame is not fully decoded yet */
+	if (result != 0) {
+		free(out->buf);
+		free(in->buf);
+		return ERROR(frame_decompress);
+	}
+
 	/* no error */
```

`ERROR(frame_decompress)` is the code the threaded path in the same files already uses for this condition.

### Behaviour change worth reviewing

Truncating only the 8-byte trailer leaves the payload intact, and today that case passes. With this change it is reported as an error. I believe that is right — the wrapped/threaded path in these same files already rejects exactly this input, brotli rejects it, and an integrity check cannot assert correctness once the checksum trailer is gone — but it is a behaviour change, so flagging it explicitly rather than burying it.

### Scope note

lz5 and lizard always wrap their output in the skippable multi-frame container (they have no `threads != 1` branch, unlike lz4), so 7-Zip-zstd's own compressor never produces a file that reaches this path for those two — it is only reachable for a raw frame from a foreign encoder. The fix is still applied there because the decompress dispatcher routes to it.

### Testing

Built x64, 0 errors, 0 warnings.

- Before / after on a 25 MB lz4 file truncated by 100 and 5000 bytes: baseline `7z t` returns 0 with `Everything is Ok` and `7z x` yields a short, SHA-256-mismatching file; the patched build reports `ERROR` with rc=2. Same pattern reproduced for lz5 and lizard using an extracted standalone raw frame.
- Regression: 16/16 (4 codecs × `-mmt1`/`-mmt4` × 1 KiB/25 MiB), full compress → test → extract → SHA-256 round trip, no new false positives.
