### PR TITLE
Clamp -mx to the codec's level range before narrowing it to Byte

### DIFF
--- a/C/zstdmt/brotli-mt.h
+++ b/C/zstdmt/brotli-mt.h
@@ -96,8 +96,9 @@ typedef struct BROTLIMT_CCtx_s BROTLIMT_CCtx;
  * 1) allocate new cctx
  * - return cctx or zero on error
  *
- * @level   - 1 .. 9
- * @threads - 1 .. BROTLIMT_THREAD_MAX
+ * @level   - BROTLIMT_LEVEL_MIN .. BROTLIMT_LEVEL_MAX
+ * @threads - 1 .. BROTLIMT_THREAD_MAX, or 0 to process a raw
+ *            brotli stream single threaded (no mt container)
  * @inputsize - if zero, becomes some optimal value for the level
  *            - if nonzero, the given value is taken
  */
@@ -132,7 +133,8 @@ typedef struct BROTLIMT_DCtx_s BROTLIMT_DCtx;
  * 1) allocate new cctx
  * - return cctx or zero on error
  *
- * @threads - 1 .. BROTLIMT_THREAD_MAX
+ * @threads - 1 .. BROTLIMT_THREAD_MAX, or 0 to process a raw
+ *            brotli stream single threaded (no mt container)
  * @ inputsize - used for single threaded standard bro format without skippable frames
  */
 BROTLIMT_DCtx *BROTLIMT_createDCtx(int threads, int threadsset, int inputsize);

--- a/C/zstdmt/brotli-mt_compress.c
+++ b/C/zstdmt/brotli-mt_compress.c
@@ -50,7 +50,7 @@ struct writelist {
 
 struct BROTLIMT_CCtx_s {
 
-	/* levels: 1..BROTLIMT_LEVEL_MAX */
+	/* level: BROTLIMT_LEVEL_MIN..BROTLIMT_LEVEL_MAX */
 	int level;
 
 	/* threads: 0..BROTLIMT_THREAD_MAX */

--- a/C/zstdmt/lizard-mt.h
+++ b/C/zstdmt/lizard-mt.h
@@ -98,7 +98,7 @@ typedef struct LIZARDMT_CCtx_s LIZARDMT_CCtx;
  * 1) allocate new cctx
  * - return cctx or zero on error
  *
- * @level   - 1 .. 9
+ * @level   - LIZARDMT_LEVEL_MIN .. LIZARDMT_LEVEL_MAX
  * @threads - 1 .. LIZARDMT_THREAD_MAX
  * @inputsize - if zero, becomes some optimal value for the level
  *            - if nonzero, the given value is taken

--- a/C/zstdmt/lizard-mt_compress.c
+++ b/C/zstdmt/lizard-mt_compress.c
@@ -51,7 +51,7 @@ struct writelist {
 
 struct LIZARDMT_CCtx_s {
 
-	/* level: 1..LIZARDMT_LEVEL_MAX */
+	/* level: LIZARDMT_LEVEL_MIN..LIZARDMT_LEVEL_MAX */
 	int level;
 
 	/* threads: 1..LIZARDMT_THREAD_MAX */

--- a/C/zstdmt/lz4-mt.h
+++ b/C/zstdmt/lz4-mt.h
@@ -98,7 +98,7 @@ typedef struct LZ4MT_CCtx_s LZ4MT_CCtx;
  * 1) allocate new cctx
  * - return cctx or zero on error
  *
- * @level   - 1 .. 9
+ * @level   - LZ4MT_LEVEL_MIN .. LZ4MT_LEVEL_MAX
  * @threads - 1 .. LZ4MT_THREAD_MAX
  * @inputsize - if zero, becomes some optimal value for the level
  *            - if nonzero, the given value is taken

--- a/C/zstdmt/lz4-mt_compress.c
+++ b/C/zstdmt/lz4-mt_compress.c
@@ -51,7 +51,7 @@ struct writelist {
 
 struct LZ4MT_CCtx_s {
 
-	/* level: 1..LZ4MT_LEVEL_MAX */
+	/* level: LZ4MT_LEVEL_MIN..LZ4MT_LEVEL_MAX */
 	int level;
 
 	/* threads: 1..LZ4MT_THREAD_MAX */

--- a/C/zstdmt/lz5-mt.h
+++ b/C/zstdmt/lz5-mt.h
@@ -98,7 +98,7 @@ typedef struct LZ5MT_CCtx_s LZ5MT_CCtx;
  * 1) allocate new cctx
  * - return cctx or zero on error
  *
- * @level   - 1 .. 9
+ * @level   - LZ5MT_LEVEL_MIN .. LZ5MT_LEVEL_MAX
  * @threads - 1 .. LZ5MT_THREAD_MAX
  * @inputsize - if zero, becomes some optimal value for the level
  *            - if nonzero, the given value is taken

--- a/C/zstdmt/lz5-mt_compress.c
+++ b/C/zstdmt/lz5-mt_compress.c
@@ -51,7 +51,7 @@ struct writelist {
 
 struct LZ5MT_CCtx_s {
 
-	/* level: 1..LZ5MT_LEVEL_MAX */
+	/* level: LZ5MT_LEVEL_MIN..LZ5MT_LEVEL_MAX */
 	int level;
 
 	/* threads: 1..LZ5MT_THREAD_MAX */

--- a/CPP/7zip/Compress/BrotliEncoder.cpp
+++ b/CPP/7zip/Compress/BrotliEncoder.cpp
@@ -50,10 +50,12 @@ Z7_COM7F_IMF(CEncoder::SetCoderProperties(const PROPID * propIDs, const PROPVARI
         if (prop.vt != VT_UI4)
           return E_INVALIDARG;
 
-        _props._level = static_cast < Byte > (prop.ulVal);
-        Byte mylevel = static_cast < Byte > (BROTLIMT_LEVEL_MAX);
-        if (_props._level > mylevel)
-          _props._level = mylevel;
+        // clamp in UInt32: narrowing first would wrap, e.g. -mx256 -> 0
+        UInt32 level = prop.ulVal;
+        if (level > (UInt32)BROTLIMT_LEVEL_MAX)
+          level = BROTLIMT_LEVEL_MAX;
+        // BROTLIMT_LEVEL_MIN is 0, which an unsigned value always satisfies
+        _props._level = static_cast < Byte > (level);
 
         break;
       }

--- a/CPP/7zip/Compress/LizardEncoder.cpp
+++ b/CPP/7zip/Compress/LizardEncoder.cpp
@@ -45,11 +45,13 @@ Z7_COM7F_IMF(CEncoder::SetCoderProperties(const PROPID * propIDs, const PROPVARI
         if (prop.vt != VT_UI4)
           return E_INVALIDARG;
 
-        /* level 1..22 */
-        _props._level = static_cast < Byte > (prop.ulVal);
-        Byte mylevel = static_cast < Byte > (LIZARDMT_LEVEL_MAX);
-        if (_props._level > mylevel)
-          _props._level = mylevel;
+        // clamp in UInt32: narrowing first would wrap, e.g. -mx256 -> 0
+        UInt32 level = prop.ulVal;
+        if (level > (UInt32)LIZARDMT_LEVEL_MAX)
+          level = LIZARDMT_LEVEL_MAX;
+        if (level < (UInt32)LIZARDMT_LEVEL_MIN)
+          level = LIZARDMT_LEVEL_MIN;
+        _props._level = static_cast < Byte > (level);
 
         break;
       }

--- a/CPP/7zip/Compress/Lz4Encoder.cpp
+++ b/CPP/7zip/Compress/Lz4Encoder.cpp
@@ -40,10 +40,13 @@ Z7_COM7F_IMF(CEncoder::SetCoderProperties(const PROPID * propIDs, const PROPVARI
         if (prop.vt != VT_UI4)
           return E_INVALIDARG;
 
-        _props._level = static_cast < Byte > (prop.ulVal);
-        Byte mylevel = static_cast < Byte > (LZ4MT_LEVEL_MAX);
-        if (_props._level > mylevel)
-          _props._level = mylevel;
+        // clamp in UInt32: narrowing first would wrap, e.g. -mx256 -> 0
+        UInt32 level = prop.ulVal;
+        if (level > (UInt32)LZ4MT_LEVEL_MAX)
+          level = LZ4MT_LEVEL_MAX;
+        if (level < (UInt32)LZ4MT_LEVEL_MIN)
+          level = LZ4MT_LEVEL_MIN;
+        _props._level = static_cast < Byte > (level);
 
         break;
       }

--- a/CPP/7zip/Compress/Lz5Encoder.cpp
+++ b/CPP/7zip/Compress/Lz5Encoder.cpp
@@ -45,10 +45,13 @@ Z7_COM7F_IMF(CEncoder::SetCoderProperties(const PROPID * propIDs, const PROPVARI
         if (prop.vt != VT_UI4)
           return E_INVALIDARG;
 
-        _props._level = static_cast < Byte > (prop.ulVal);
-        Byte mylevel = static_cast < Byte > (LZ5MT_LEVEL_MAX);
-        if (_props._level > mylevel)
-          _props._level = mylevel;
+        // clamp in UInt32: narrowing first would wrap, e.g. -mx256 -> 0
+        UInt32 level = prop.ulVal;
+        if (level > (UInt32)LZ5MT_LEVEL_MAX)
+          level = LZ5MT_LEVEL_MAX;
+        if (level < (UInt32)LZ5MT_LEVEL_MIN)
+          level = LZ5MT_LEVEL_MIN;
+        _props._level = static_cast < Byte > (level);
 
         break;
       }

--- a/tests/main.test
+++ b/tests/main.test
@@ -76,6 +76,51 @@ test main--pipe-a-to-e {7z simple compression / decompression via std-pipes} {
 	set _ OK
 } OK
 
+test main--pipe-a-to-e-mx0 {7z simple compression / decompression via std-pipes, level 0} {
+	variable Z7_PATH
+	foreach t {zstd brotli bzip2 xz gzip lz4 lz5 lizard} {
+		if {[catch {
+			7z a -t$t -mx0 -si -so << "$t: This is a test string passed to stdin" . | $Z7_PATH e -t$t -si -so
+		} res]} {
+			error "Test of -t$t failed: $res"
+		}
+		assertLogged "^$t: This is a test string passed to stdin$"
+	}
+	set _ OK
+} OK
+
+test main--compress-mx0 {7z simple compression / decompression, level 0} -setup {
+	set tmpdir [file join [temporaryDirectory] 7z-test-[format %x-%lx [pid] [clock microseconds]]]
+	file mkdir $tmpdir
+} -body {
+	variable Z7_PATH
+	foreach t {zstd brotli LZMA2 lz4 lz5 lizard} {
+		set arcpath [file join $tmpdir test.$t.7z]
+		set v "$t: This is a test string passed to stdin"
+		if {[catch {
+			# compress:
+			7z a -t7z -m0=$t:x0 -sitest.txt -- $arcpath . << "$v"
+			assertLogged {\nCreating archive} \
+				{\nAdd new data to archive: 1 file} \
+				{\nEverything is Ok}
+			# test:
+			7z t -- $arcpath
+			assertLogged {\nEverything is Ok}
+			# decompress:
+			set v2 [7z e -so -- $arcpath]
+			#puts $v2
+			if {$v2 ne $v} {
+				error "retrieved $v2 instead of original"
+			}
+		} res]} {
+			error "Test of -t$t failed: $res"
+		}
+	}
+	set _ OK
+} -cleanup {
+	file delete -force $tmpdir
+} -result OK
+
 test main--mmt-option {7z force multi-threaded & single-threaded compression / decompression} {
 	variable Z7_PATH
 	foreach mt {=on =off =1 =2 d2 d-2 p25u1 p1+1} {


### PR DESCRIPTION
Fixes #543.

Clamps in `UInt32` before narrowing to `Byte`, which covers both the missing lower bound and the wrap:

```c
UInt32 level = prop.ulVal;
if (level > (UInt32)LIZARDMT_LEVEL_MAX)
  level = LIZARDMT_LEVEL_MAX;
if (level < (UInt32)LIZARDMT_LEVEL_MIN)
  level = LIZARDMT_LEVEL_MIN;
_props._level = static_cast < Byte > (level);
```

brotli gets the upper clamp only: its `LEVEL_MIN` is 0, which an unsigned value satisfies by construction, and `level < 0u` would be a tautological comparison that `-Wall -Wextra -Werror` in the gcc/clang builds may well reject.

Also drops the stale `/* level 1..22 */` comment in `LizardEncoder.cpp` that the rewritten block replaced — Lizard's range is 10..49.

A second commit fixes the same range where it is documented. All four `C/zstdmt/*-mt.h` say `@level - 1 .. 9` for `*MT_createCCtx()`, and none of the four actual ranges is 1..9 (1..12, 1..15, 10..49, 0..11) — those are the ranges `*MT_createCCtx()` already enforces on its own (`brotli-mt_compress.c:111`, the other three at `:107`). The struct comment above `int level;` in each `*-mt_compress.c` is off the same way, right for lz4/lz5 and wrong for lizard and brotli. And brotli's `@threads - 1 .. BROTLIMT_THREAD_MAX` misses that 0 is accepted on purpose there, selecting the raw single-threaded path, where the other three really do reject it.

All of it is written with the macro names, the way `@threads` already was, so the comments cannot drift from the constants again. Comments only — no behaviour change in that commit.

### Testing

Built x64, 0 errors, 0 warnings (`-W4 -WX`), from a cleaned object directory (the header-comment commit alone would otherwise not trigger a rebuild).

- 4 codecs × `-mx0/1/9/255/256/300`, compress + `7z t`, before and after. Before: 8 failures (lz4/lz5 `-mx0` and `-mx256`, lizard `-mx0/1/9` and `-mx256`). After: 24/24 pass, and the sizes are monotone — `-mx255`, `-mx256` and `-mx300` now all give the same archive as the codec's maximum level, where before `-mx256` either failed or (brotli) silently produced the *lowest*-level output.
- Round-trip suite, 42 cases (6 codecs in `.7z` × `-mmt1/-mmt4` × compressible/incompressible, plus the standalone `.lz4/.lz5/.liz/.zst/.br` formats), SHA-256 verified: 42/42, the same result as an unpatched master build (8046864f).
