### PR TITLE
Validate parameters before allocating the context

### DIFF
--- a/C/zstdmt/brotli-mt_compress.c
+++ b/C/zstdmt/brotli-mt_compress.c
@@ -98,17 +98,17 @@ BROTLIMT_CCtx *BROTLIMT_createCCtx(int threads, uint64_t unpackSize, int level, 
 	BROTLIMT_CCtx *ctx;
 	int t;
 
-	/* allocate ctx */
-	ctx = (BROTLIMT_CCtx *) malloc(sizeof(BROTLIMT_CCtx));
-	if (!ctx)
-		return 0;
-
 	/* check threads value */
 	if (threads < 0 || threads > BROTLIMT_THREAD_MAX)
 		return 0;
 
 	/* check level */
 	if (level < BROTLIMT_LEVEL_MIN || level > BROTLIMT_LEVEL_MAX)
+		return 0;
+
+	/* allocate ctx */
+	ctx = (BROTLIMT_CCtx *) malloc(sizeof(BROTLIMT_CCtx));
+	if (!ctx)
 		return 0;
 
 	/* calculate chunksize for one thread */

--- a/C/zstdmt/brotli-mt_decompress.c
+++ b/C/zstdmt/brotli-mt_decompress.c
@@ -90,13 +90,13 @@ BROTLIMT_DCtx *BROTLIMT_createDCtx(int threads, int inputsize)
 	BROTLIMT_DCtx *ctx;
 	int t;
 
+	/* check threads value */
+	if (threads < 0 || threads > BROTLIMT_THREAD_MAX)
+		return 0;
+
 	/* allocate ctx */
 	ctx = (BROTLIMT_DCtx *) malloc(sizeof(BROTLIMT_DCtx));
 	if (!ctx)
-		return 0;
-
-	/* check threads value */
-	if (threads < 0 || threads > BROTLIMT_THREAD_MAX)
 		return 0;
 
 	/* setup ctx */

--- a/C/zstdmt/brotli-mt_decompress.c
+++ b/C/zstdmt/brotli-mt_decompress.c
@@ -331,7 +331,6 @@ static void *pt_decompress(void *arg)
 		/* zero should not happen here! */
 		result = pt_read(ctx, in, &wl->frame, &wl->out.size);
 		if (BROTLIMT_isError(result)) {
-			list_move(&wl->node, &ctx->writelist_free);
 			goto error_lock;
 		}
 

--- a/C/zstdmt/lizard-mt_compress.c
+++ b/C/zstdmt/lizard-mt_compress.c
@@ -94,17 +94,17 @@ LIZARDMT_CCtx *LIZARDMT_createCCtx(int threads, int level, int inputsize)
 	LIZARDMT_CCtx *ctx;
 	int t;
 
-	/* allocate ctx */
-	ctx = (LIZARDMT_CCtx *) malloc(sizeof(LIZARDMT_CCtx));
-	if (!ctx)
-		return 0;
-
 	/* check threads value */
 	if (threads < 1 || threads > LIZARDMT_THREAD_MAX)
 		return 0;
 
 	/* check level */
 	if (level < LIZARDMT_LEVEL_MIN || level > LIZARDMT_LEVEL_MAX)
+		return 0;
+
+	/* allocate ctx */
+	ctx = (LIZARDMT_CCtx *) malloc(sizeof(LIZARDMT_CCtx));
+	if (!ctx)
 		return 0;
 
 	/* calculate chunksize for one thread */

--- a/C/zstdmt/lizard-mt_decompress.c
+++ b/C/zstdmt/lizard-mt_decompress.c
@@ -92,13 +92,13 @@ LIZARDMT_DCtx *LIZARDMT_createDCtx(int threads, int inputsize)
 	LIZARDMT_DCtx *ctx;
 	int t;
 
+	/* check threads value */
+	if (threads < 1 || threads > LIZARDMT_THREAD_MAX)
+		return 0;
+
 	/* allocate ctx */
 	ctx = (LIZARDMT_DCtx *) malloc(sizeof(LIZARDMT_DCtx));
 	if (!ctx)
-		return 0;
-
-	/* check threads value */
-	if (threads < 1 || threads > LIZARDMT_THREAD_MAX)
 		return 0;
 
 	/* setup ctx */

--- a/C/zstdmt/lz4-mt_compress.c
+++ b/C/zstdmt/lz4-mt_compress.c
@@ -94,17 +94,17 @@ LZ4MT_CCtx *LZ4MT_createCCtx(int threads, int level, int inputsize)
 	LZ4MT_CCtx *ctx;
 	int t;
 
-	/* allocate ctx */
-	ctx = (LZ4MT_CCtx *) malloc(sizeof(LZ4MT_CCtx));
-	if (!ctx)
-		return 0;
-
 	/* check threads value */
 	if (threads < 1 || threads > LZ4MT_THREAD_MAX)
 		return 0;
 
 	/* check level */
 	if (level < LZ4MT_LEVEL_MIN || level > LZ4MT_LEVEL_MAX)
+		return 0;
+
+	/* allocate ctx */
+	ctx = (LZ4MT_CCtx *) malloc(sizeof(LZ4MT_CCtx));
+	if (!ctx)
 		return 0;
 
 	/* calculate chunksize for one thread */

--- a/C/zstdmt/lz4-mt_decompress.c
+++ b/C/zstdmt/lz4-mt_decompress.c
@@ -92,13 +92,13 @@ LZ4MT_DCtx *LZ4MT_createDCtx(int threads, int inputsize)
 	LZ4MT_DCtx *ctx;
 	int t;
 
+	/* check threads value */
+	if (threads < 1 || threads > LZ4MT_THREAD_MAX)
+		return 0;
+
 	/* allocate ctx */
 	ctx = (LZ4MT_DCtx *) malloc(sizeof(LZ4MT_DCtx));
 	if (!ctx)
-		return 0;
-
-	/* check threads value */
-	if (threads < 1 || threads > LZ4MT_THREAD_MAX)
 		return 0;
 
 	/* setup ctx */

--- a/C/zstdmt/lz5-mt_compress.c
+++ b/C/zstdmt/lz5-mt_compress.c
@@ -94,17 +94,17 @@ LZ5MT_CCtx *LZ5MT_createCCtx(int threads, int level, int inputsize)
 	LZ5MT_CCtx *ctx;
 	int t;
 
-	/* allocate ctx */
-	ctx = (LZ5MT_CCtx *) malloc(sizeof(LZ5MT_CCtx));
-	if (!ctx)
-		return 0;
-
 	/* check threads value */
 	if (threads < 1 || threads > LZ5MT_THREAD_MAX)
 		return 0;
 
 	/* check level */
 	if (level < LZ5MT_LEVEL_MIN || level > LZ5MT_LEVEL_MAX)
+		return 0;
+
+	/* allocate ctx */
+	ctx = (LZ5MT_CCtx *) malloc(sizeof(LZ5MT_CCtx));
+	if (!ctx)
 		return 0;
 
 	/* calculate chunksize for one thread */

--- a/C/zstdmt/lz5-mt_decompress.c
+++ b/C/zstdmt/lz5-mt_decompress.c
@@ -92,13 +92,13 @@ LZ5MT_DCtx *LZ5MT_createDCtx(int threads, int inputsize)
 	LZ5MT_DCtx *ctx;
 	int t;
 
+	/* check threads value */
+	if (threads < 1 || threads > LZ5MT_THREAD_MAX)
+		return 0;
+
 	/* allocate ctx */
 	ctx = (LZ5MT_DCtx *) malloc(sizeof(LZ5MT_DCtx));
 	if (!ctx)
-		return 0;
-
-	/* check threads value */
-	if (threads < 1 || threads > LZ5MT_THREAD_MAX)
 		return 0;
 
 	/* setup ctx */

--- a/CPP/7zip/Compress/BrotliDecoder.cpp
+++ b/CPP/7zip/Compress/BrotliDecoder.cpp
@@ -76,6 +76,12 @@ CDecoder::CDecoder():
   _inputSize(0),
   _numThreads(NWindows::NSystem::GetNumberOfProcessors())
 {
+  // GetNumberOfProcessors() is uncapped and sums all processor groups, while
+  // BROTLIMT_createDCtx() only accepts up to BROTLIMT_THREAD_MAX.
+  // BrotliHandler does call SetNumberOfThreads(), but the default has to be
+  // valid on its own.
+  if (_numThreads > (UInt32)BROTLIMT_THREAD_MAX)
+    _numThreads = (UInt32)BROTLIMT_THREAD_MAX;
   _props.clear();
 }
 

--- a/CPP/7zip/Compress/BrotliEncoder.cpp
+++ b/CPP/7zip/Compress/BrotliEncoder.cpp
@@ -18,6 +18,12 @@ CEncoder::CEncoder():
   unpackSize(0),
   _ctx(NULL)
 {
+  // GetNumberOfProcessors() is uncapped and sums all processor groups, while
+  // BROTLIMT_createCCtx() only accepts up to BROTLIMT_THREAD_MAX.
+  // BrotliHandler does call SetNumberOfThreads(), but the default has to be
+  // valid on its own.
+  if (_numThreads > (UInt32)BROTLIMT_THREAD_MAX)
+    _numThreads = (UInt32)BROTLIMT_THREAD_MAX;
   _props.clear();
 }
 

--- a/CPP/7zip/Compress/LizardDecoder.cpp
+++ b/CPP/7zip/Compress/LizardDecoder.cpp
@@ -76,6 +76,11 @@ CDecoder::CDecoder():
   _inputSize(0),
   _numThreads(NWindows::NSystem::GetNumberOfProcessors())
 {
+  // GetNumberOfProcessors() is uncapped and sums all processor groups, while
+  // LIZARDMT_createDCtx() only accepts up to LIZARDMT_THREAD_MAX.
+  // LizardHandler never calls SetNumberOfThreads(), so clamp here too.
+  if (_numThreads > (UInt32)LIZARDMT_THREAD_MAX)
+    _numThreads = (UInt32)LIZARDMT_THREAD_MAX;
   _props.clear();
 }
 

--- a/CPP/7zip/Compress/LizardEncoder.cpp
+++ b/CPP/7zip/Compress/LizardEncoder.cpp
@@ -15,6 +15,11 @@ CEncoder::CEncoder():
   _numThreads(NWindows::NSystem::GetNumberOfProcessors()),
   _ctx(NULL)
 {
+  // GetNumberOfProcessors() is uncapped and sums all processor groups, while
+  // LIZARDMT_createCCtx() only accepts up to LIZARDMT_THREAD_MAX.
+  // LizardHandler never calls SetNumberOfThreads(), so clamp here too.
+  if (_numThreads > (UInt32)LIZARDMT_THREAD_MAX)
+    _numThreads = (UInt32)LIZARDMT_THREAD_MAX;
   _props.clear();
 }
 

--- a/CPP/7zip/Compress/Lz4Decoder.cpp
+++ b/CPP/7zip/Compress/Lz4Decoder.cpp
@@ -76,6 +76,11 @@ CDecoder::CDecoder():
   _inputSize(0),
   _numThreads(NWindows::NSystem::GetNumberOfProcessors())
 {
+  // GetNumberOfProcessors() is uncapped and sums all processor groups, while
+  // LZ4MT_createDCtx() only accepts up to LZ4MT_THREAD_MAX. Lz4Handler never
+  // calls SetNumberOfThreads(), so clamp here too.
+  if (_numThreads > (UInt32)LZ4MT_THREAD_MAX)
+    _numThreads = (UInt32)LZ4MT_THREAD_MAX;
   _props.clear();
 }
 

--- a/CPP/7zip/Compress/Lz5Decoder.cpp
+++ b/CPP/7zip/Compress/Lz5Decoder.cpp
@@ -76,6 +76,11 @@ CDecoder::CDecoder():
   _inputSize(0),
   _numThreads(NWindows::NSystem::GetNumberOfProcessors())
 {
+  // GetNumberOfProcessors() is uncapped and sums all processor groups, while
+  // LZ5MT_createDCtx() only accepts up to LZ5MT_THREAD_MAX. Lz5Handler never
+  // calls SetNumberOfThreads(), so clamp here too.
+  if (_numThreads > (UInt32)LZ5MT_THREAD_MAX)
+    _numThreads = (UInt32)LZ5MT_THREAD_MAX;
   _props.clear();
 }
 

--- a/CPP/7zip/Compress/Lz5Encoder.cpp
+++ b/CPP/7zip/Compress/Lz5Encoder.cpp
@@ -15,6 +15,11 @@ CEncoder::CEncoder():
   _numThreads(NWindows::NSystem::GetNumberOfProcessors()),
   _ctx(NULL)
 {
+  // GetNumberOfProcessors() is uncapped and sums all processor groups, while
+  // LZ5MT_createCCtx() only accepts up to LZ5MT_THREAD_MAX. Lz5Handler never
+  // calls SetNumberOfThreads(), so clamp here too.
+  if (_numThreads > (UInt32)LZ5MT_THREAD_MAX)
+    _numThreads = (UInt32)LZ5MT_THREAD_MAX;
   _props.clear();
 }
 


### PR DESCRIPTION
Fixes #545.

**Commit 1** moves the existing checks ahead of the `malloc()` in all eight factories. The checks themselves are copied across unchanged, including brotli's deliberate `threads < 0` lower bound (0 is its single-threaded sentinel) against `threads < 1` for the other three. Nothing in any of the checks reads `ctx`, so the move is mechanical.

**Commit 2** clamps the constructor default for `_numThreads` to `*_THREAD_MAX` in the seven coders that default to `GetNumberOfProcessors()`. `Lz4Encoder` already defaults to 1 and is untouched.

**Commit 3** drops the unlocked `list_move()` from brotli's `pt_read()` failure branch, leaving the `goto error_lock;` that the other three codecs have on their own. `error_lock:` takes the lock and performs that same move, so the entry still gets returned — just under the mutex, once.

### Not addressed here

The wider question of whether `Lz4Handler` / `Lz5Handler` / `LizardHandler` *should* call `SetNumberOfThreads()` the way `BrotliHandler` does — which would also make `-mmt` take effect for the standalone `.lz4` / `.lz5` / `.liz` formats — is a behaviour change rather than a fix, so it is left out. The clamp here only makes the default valid on its own.

### Testing

Built x64, 0 errors, 0 warnings.

- Leak, measured in-process with the CRT debug heap against a program linking the real sources, 100 iterations per case: **before 216–224 bytes per call on every rejection path** (8 cases for lz4/lz5/lizard, 6 for brotli — brotli's two `threads == 0` cases are accepted, not rejected, and are reported as skipped); **after 0 on all of them**, with brotli's sentinel still accepted.
- `-mmt=0/1/4/200` × 4 codecs: identical results before and after (this machine has 22 threads, so the clamp is a no-op here, as expected).
- Commit 3's path driven directly — reader hands out the container magic and then fails — at `threads=1` (inline) and `threads=4` (real workers), 100 iterations each, measured on the same debug heap: `read_fail` returned, no crash and no leak, **identical before and after**. A data race is not something a deterministic test can show, so what this checks is the other half: that dropping the call does not change the outcome of that path.
- Round-trip suite, 42 cases, SHA-256 verified: 42/42, the same result as an unpatched master build (8046864f).
