### PR TITLE
Don't give back a writelist entry that was never acquired

### DIFF
--- a/C/zstdmt/brotli-mt_decompress.c
+++ b/C/zstdmt/brotli-mt_decompress.c
@@ -318,7 +318,8 @@ static void *pt_decompress(void *arg)
 			    malloc(sizeof(struct writelist));
 			if (!wl) {
 				result = MT_ERROR(memory_allocation);
-				goto error_unlock;
+				/* @wl was never acquired, nothing to give back */
+				goto error_unlock_nowl;
 			}
 			wl->out.buf = 0;
 			wl->out.size = 0;
@@ -374,6 +375,7 @@ static void *pt_decompress(void *arg)
 	pthread_mutex_lock(&ctx->write_mutex);
  error_unlock:
 	list_move(&wl->node, &ctx->writelist_free);
+ error_unlock_nowl:
 	pthread_mutex_unlock(&ctx->write_mutex);
 	if (in->allocated)
 		free(in->buf);

--- a/C/zstdmt/lizard-mt_decompress.c
+++ b/C/zstdmt/lizard-mt_decompress.c
@@ -305,7 +305,8 @@ static void *pt_decompress(void *arg)
 			    malloc(sizeof(struct writelist));
 			if (!wl) {
 				result = ERROR(memory_allocation);
-				goto error_unlock;
+				/* @wl was never acquired, nothing to give back */
+				goto error_unlock_nowl;
 			}
 			wl->out.buf = 0;
 			wl->out.size = 0;
@@ -385,6 +386,7 @@ static void *pt_decompress(void *arg)
 	pthread_mutex_lock(&ctx->write_mutex);
  error_unlock:
 	list_move(&wl->node, &ctx->writelist_free);
+ error_unlock_nowl:
 	pthread_mutex_unlock(&ctx->write_mutex);
 	if (in->allocated)
 		free(in->buf);

--- a/C/zstdmt/lz4-mt_decompress.c
+++ b/C/zstdmt/lz4-mt_decompress.c
@@ -305,7 +305,8 @@ static void *pt_decompress(void *arg)
 			    malloc(sizeof(struct writelist));
 			if (!wl) {
 				result = ERROR(memory_allocation);
-				goto error_unlock;
+				/* @wl was never acquired, nothing to give back */
+				goto error_unlock_nowl;
 			}
 			wl->out.buf = 0;
 			wl->out.size = 0;
@@ -384,6 +385,7 @@ static void *pt_decompress(void *arg)
 	pthread_mutex_lock(&ctx->write_mutex);
  error_unlock:
 	list_move(&wl->node, &ctx->writelist_free);
+ error_unlock_nowl:
 	pthread_mutex_unlock(&ctx->write_mutex);
 	if (in->allocated)
 		free(in->buf);

--- a/C/zstdmt/lz5-mt_decompress.c
+++ b/C/zstdmt/lz5-mt_decompress.c
@@ -305,7 +305,8 @@ static void *pt_decompress(void *arg)
 			    malloc(sizeof(struct writelist));
 			if (!wl) {
 				result = ERROR(memory_allocation);
-				goto error_unlock;
+				/* @wl was never acquired, nothing to give back */
+				goto error_unlock_nowl;
 			}
 			wl->out.buf = 0;
 			wl->out.size = 0;
@@ -384,6 +385,7 @@ static void *pt_decompress(void *arg)
 	pthread_mutex_lock(&ctx->write_mutex);
  error_unlock:
 	list_move(&wl->node, &ctx->writelist_free);
+ error_unlock_nowl:
 	pthread_mutex_unlock(&ctx->write_mutex);
 	if (in->allocated)
 		free(in->buf);


### PR DESCRIPTION
Fixes #547.

Adds a second entry point past the `list_move()` and jumps there from the allocation-failure branch:

```diff
 			if (!wl) {
 				result = ERROR(memory_allocation);
-				goto error_unlock;
+				/* @wl was never acquired, nothing to give back */
+				goto error_unlock_nowl;
 			}
@@
  error_unlock:
 	list_move(&wl->node, &ctx->writelist_free);
+ error_unlock_nowl:
 	pthread_mutex_unlock(&ctx->write_mutex);
```

The other user of `error_unlock:` — the `pt_write()` failure path — still holds a valid `wl` and is unchanged. Four files, same edit in each.

A `if (wl)` guard on the `list_move()` would work too (`wl` is reassigned on every iteration, so it is never stale). I went with the extra label because it keeps "this path has no entry to give back" a property of the path rather than something the epilogue has to re-derive, and because it leaves the hot path untouched — happy to switch if you prefer the guard.

### Testing

Built x64, 0 errors, 0 warnings.

- Allocation-failure POC as above, all four codecs: **before, access violation reading address 0x20; after, clean return with `Allocation error : not enough memory`**. The interposer fires exactly once, on the one allocation matching `sizeof(struct writelist)`, and only after the context is built, so nothing else in the path is perturbed.
- Round-trip suite, 42 cases, SHA-256 verified: 42/42, the same result as an unpatched master build (8046864f).
