### PR TITLE
Fix extracting multiple LZ5/Lizard frames

### DIFF
--- a/C/zstdmt/lizard-mt_decompress.c
+++ b/C/zstdmt/lizard-mt_decompress.c
@@ -395,13 +395,12 @@ static void *pt_decompress(void *arg)
 static size_t st_decompress(void *arg)
 {
 	LIZARDMT_DCtx *ctx = (LIZARDMT_DCtx *) arg;
-	LizardF_errorCode_t nextToLoad = 0;
+	LizardF_errorCode_t result = 0;
 	cwork_t *w = &ctx->cwork[0];
 	LIZARDMT_Buffer Out;
 	LIZARDMT_Buffer *out = &Out;
 	LIZARDMT_Buffer *in = &w->in;
 	void *magic = in->buf;
-	size_t pos = 0;
 	int rv;
 
 	/* allocate space for input buffer */
@@ -422,46 +421,28 @@ static size_t st_decompress(void *arg)
 	in->size = 4;
 	memcpy(in->buf, magic, in->size);
 
-	nextToLoad =
-	    LizardF_decompress(w->dctx, out->buf, &pos, in->buf, &in->size, 0);
-	if (LizardF_isError(nextToLoad)) {
-		free(in->buf);
-		free(out->buf);
-		return ERROR(compression_library);
-	}
+	/* stats */
+	ctx->insize = 4;
+	ctx->outsize = 0;
 
-	for (; nextToLoad; pos = 0) {
-		if (nextToLoad > ctx->inputsize)
-			nextToLoad = ctx->inputsize;
-
-		/* read new input */
-		in->size = nextToLoad;
-		rv = ctx->fn_read(ctx->arg_read, in);
-		if (rv != 0) {
-			free(in->buf);
-			free(out->buf);
-			return mt_error(rv);
-		}
-
-		/* done, eof reached */
-		if (in->size == 0)
-			break;
-
-		/* still to read, or still to flush */
-		while ((pos < in->size) || (out->size == ctx->inputsize)) {
-			size_t remaining = in->size - pos;
+	/* decompress loop */
+	for (;;) {
+		size_t srcPos = 0;
+		for (;;) {
+			size_t srcSize = in->size - srcPos;
 			out->size = ctx->inputsize;
 
-			/* decompress */
-			nextToLoad =
-			    LizardF_decompress(w->dctx, out->buf, &out->size,
-					    (unsigned char *)in->buf + pos,
-					    &remaining, NULL);
-			if (LizardF_isError(nextToLoad)) {
+			result = LizardF_decompress(w->dctx, out->buf, &out->size, (unsigned char *)in->buf + srcPos, &srcSize, NULL);
+			if (LizardF_isError(result)) {
 				free(in->buf);
 				free(out->buf);
 				return ERROR(compression_library);
 			}
+
+			/* update stats */
+			srcPos += srcSize;
+			ctx->insize += srcSize;
+			ctx->outsize += out->size;
 
 			/* have some output */
 			if (out->size) {
@@ -473,15 +454,34 @@ static size_t st_decompress(void *arg)
 				}
 			}
 
-			if (nextToLoad == 0)
+			/* consumed all input */
+			if (srcPos == in->size)
 				break;
-
-			pos += remaining;
 		}
+
+		/* read new input */
+		if (result)
+			in->size = result;
+		else
+			in->size = ctx->inputsize;
+
+		if (in->size > ctx->inputsize)
+			in->size = ctx->inputsize;
+
+		rv = ctx->fn_read(ctx->arg_read, in);
+		ctx->insize += in->size;
+		if (rv != 0) {
+			free(in->buf);
+			free(out->buf);
+			return mt_error(rv);
+		}
+
+		if (in->size == 0)
+			break;
 	}
 
 	/* input ended, but current frame is not fully decoded yet */
-	if (nextToLoad != 0) {
+	if (result != 0) {
 		free(out->buf);
 		free(in->buf);
 		return ERROR(frame_decompress);

--- a/C/zstdmt/lz5-mt_decompress.c
+++ b/C/zstdmt/lz5-mt_decompress.c
@@ -394,13 +394,12 @@ static void *pt_decompress(void *arg)
 static size_t st_decompress(void *arg)
 {
 	LZ5MT_DCtx *ctx = (LZ5MT_DCtx *) arg;
-	LZ5F_errorCode_t nextToLoad = 0;
+	LZ5F_errorCode_t result = 0;
 	cwork_t *w = &ctx->cwork[0];
 	LZ5MT_Buffer Out;
 	LZ5MT_Buffer *out = &Out;
 	LZ5MT_Buffer *in = &w->in;
 	void *magic = in->buf;
-	size_t pos = 0;
 	int rv;
 
 	/* allocate space for input buffer */
@@ -421,46 +420,28 @@ static size_t st_decompress(void *arg)
 	in->size = 4;
 	memcpy(in->buf, magic, in->size);
 
-	nextToLoad =
-	    LZ5F_decompress(w->dctx, out->buf, &pos, in->buf, &in->size, 0);
-	if (LZ5F_isError(nextToLoad)) {
-		free(in->buf);
-		free(out->buf);
-		return ERROR(compression_library);
-	}
+	/* stats */
+	ctx->insize = 4;
+	ctx->outsize = 0;
 
-	for (; nextToLoad; pos = 0) {
-		if (nextToLoad > ctx->inputsize)
-			nextToLoad = ctx->inputsize;
-
-		/* read new input */
-		in->size = nextToLoad;
-		rv = ctx->fn_read(ctx->arg_read, in);
-		if (rv != 0) {
-			free(in->buf);
-			free(out->buf);
-			return mt_error(rv);
-		}
-
-		/* done, eof reached */
-		if (in->size == 0)
-			break;
-
-		/* still to read, or still to flush */
-		while ((pos < in->size) || (out->size == ctx->inputsize)) {
-			size_t remaining = in->size - pos;
+	/* decompress loop */
+	for (;;) {
+		size_t srcPos = 0;
+		for (;;) {
+			size_t srcSize = in->size - srcPos;
 			out->size = ctx->inputsize;
 
-			/* decompress */
-			nextToLoad =
-			    LZ5F_decompress(w->dctx, out->buf, &out->size,
-					    (unsigned char *)in->buf + pos,
-					    &remaining, NULL);
-			if (LZ5F_isError(nextToLoad)) {
+			result = LZ5F_decompress(w->dctx, out->buf, &out->size, (unsigned char *)in->buf + srcPos, &srcSize, NULL);
+			if (LZ5F_isError(result)) {
 				free(in->buf);
 				free(out->buf);
 				return ERROR(compression_library);
 			}
+
+			/* update stats */
+			srcPos += srcSize;
+			ctx->insize += srcSize;
+			ctx->outsize += out->size;
 
 			/* have some output */
 			if (out->size) {
@@ -472,15 +453,34 @@ static size_t st_decompress(void *arg)
 				}
 			}
 
-			if (nextToLoad == 0)
+			/* consumed all input */
+			if (srcPos == in->size)
 				break;
-
-			pos += remaining;
 		}
+
+		/* read new input */
+		if (result)
+			in->size = result;
+		else
+			in->size = ctx->inputsize;
+
+		if (in->size > ctx->inputsize)
+			in->size = ctx->inputsize;
+
+		rv = ctx->fn_read(ctx->arg_read, in);
+		ctx->insize += in->size;
+		if (rv != 0) {
+			free(in->buf);
+			free(out->buf);
+			return mt_error(rv);
+		}
+
+		if (in->size == 0)
+			break;
 	}
 
 	/* input ended, but current frame is not fully decoded yet */
-	if (nextToLoad != 0) {
+	if (result != 0) {
 		free(out->buf);
 		free(in->buf);
 		return ERROR(frame_decompress);


### PR DESCRIPTION
Fixes #549.

Ports lz4's `st_decompress()` across verbatim — only the `LZ4MT_` → `LZ5MT_` / `LIZARDMT_` and `LZ4F_` → `LZ5F_` / `LizardF_` prefixes change, formatting and all. After the substitution the three functions `diff` clean against each other, which is also the easiest way to review this: it is 71a0a67a applied to the two files it missed.

That brings over the `ctx->insize` / `ctx->outsize` accounting the lz4 rewrite added, which lz5/lizard's `st_decompress()` never did (it left both at 0).

The premise was checked before porting: `lz5frame.h:300` and `lizard_frame.h:292` carry the same sentence as `lz4frame.h:499` — "After a frame is fully decoded, dctx can be used again to decompress another frame" — and both reset `dStage` to `dstage_getHeader` at a frame boundary (`lz5frame.c:1341,1380`, `lizard_frame.c:1230,1264`).

### The truncation check comes along with it

`a52873cf` added the "input ended mid-frame" check to all three files, testing a variable spelled `nextToLoad` in lz5/lizard and `result` in lz4. Porting lz4's body across brings that check to lz5/lizard in the `result` spelling — the same check, now written identically in all three.

It also starts firing where it could not before: while the loop stopped at the end of frame 1, a truncated *later* frame was never reached, so the check saw a completed frame and passed. See the truncation line under Testing.

### Not addressed here

`*MT_GetInsizeDCtx()` now double-counts: bytes are added when read and again when consumed, so it reports 2× the real input. That is inherited from the lz4 implementation — unpatched lz4 on master reports the same 2×. Fixing it here would break the "identical to lz4" property that makes this diff easy to check, and it has no consumer: the accessor has zero call sites in the tree (7-Zip tracks progress through its own read/write callbacks, `Lz5Decoder.cpp:128,133`). Worth a separate change covering all four codecs.

### Testing

Built x64, 0 errors, 0 warnings.

- The frame-combination test above, before and after, with lz4 as the control: **before, lz5 and lizard fail 4 of 7 cases; after, 7/7 for all three codecs, and the recovered bytes match the individually-decoded frames exactly**. The cases deliberately use *different* frames, so "decoded something" cannot pass for "decoded correctly" — a stale-dictionary bug between frames would show up as a content mismatch.
- Truncated and trailing-garbage input (frame A followed by a cut-short frame B, and by 3 stray bytes): on master lz5/lizard return 0 for both, because they stop at the end of A and `a52873cf`'s check only ever sees a completed frame. After, both report `Could not decompress frame at once`, matching lz4.
- Round-trip suite, 42 cases, SHA-256 verified: 42/42, the same result as an unpatched master build (8046864f).
