### PR TITLE
Fix "Add to <name>.7z" sending the registry "not specified" marker to 7zG (gh-479)

### DIFF
--- a/CPP/7zip/UI/Common/CompressCall.cpp
+++ b/CPP/7zip/UI/Common/CompressCall.cpp
@@ -285,6 +285,20 @@ HRESULT CompressFiles(
         params += temp;
       }
 
+      /* the "Memory usage" limit of the dialog. CCompressDialog stores it as
+         the spec string that CMemUse::Parse() understands ("70%", "2G", ...),
+         and as an empty string for the default entry. The dialog sends the
+         same limit as the "memuse" property, only spelled differently: it
+         re-serializes the parsed value, so an absolute limit goes out as
+         "<bytes>b" (SetOutProperties() / AddProp_Size() in UpdateGUI.cpp).
+         Both spellings reach the same ParseSizeString(), so forwarding the
+         stored string is equivalent. */
+      if (!fo.MemUse.IsEmpty())
+      {
+        params += " -mmemuse=";
+        params += fo.MemUse;
+      }
+
       if (!fo.Options.IsEmpty())
       {
         UStringVector strings;

--- a/CPP/7zip/UI/Common/CompressCall.cpp
+++ b/CPP/7zip/UI/Common/CompressCall.cpp
@@ -228,6 +228,15 @@ HRESULT CompressFiles(
     {
       char temp[64];
       const NCompression::CFormatOptions &fo = m_RegistryInfo.Formats[index];
+      /* (UInt32)(Int32)-1 is the "not specified" marker of CFormatOptions
+         (ZipRegistry.h). Key_Get_UInt32() also returns it for a registry value
+         that is absent, and FindRegistryFormatAlways() appends a default
+         constructed CFormatOptions if the format has no registry key at all.
+         Such a field must not be forwarded as a number.
+         0 in contrast is a real user selection for Level (store) and for
+         BlockLogSize (non-solid), but it is not a value that the dialog can
+         store for Dictionary or NumThreads, hence the different tests below. */
+      const UInt32 kNotDefined = (UInt32)(Int32)-1;
 
       if (!fo.Method.IsEmpty())
       {
@@ -235,14 +244,15 @@ HRESULT CompressFiles(
         params += fo.Method;
       }
 
-      if (fo.Level)
+      // level 0 (store) is a valid value, so it must be sent too
+      if (fo.Level != kNotDefined)
       {
         params += " -mx=";
         ConvertUInt32ToString(fo.Level, temp);
         params += temp;
       }
 
-      if (fo.Dictionary && (arcType == L"7z"))
+      if (fo.Dictionary && fo.Dictionary != kNotDefined && (arcType == L"7z"))
       {
         params += " -md=";
         ConvertUInt32ToString(fo.Dictionary, temp);
@@ -250,15 +260,25 @@ HRESULT CompressFiles(
         params += "b";
       }
 
-      if (fo.BlockLogSize && (arcType == L"7z"))
+      if (fo.BlockLogSize != kNotDefined && (arcType == L"7z"))
       {
+        /* keep in sync with CCompressDialog::OnOK() in
+           CPP/7zip/UI/GUI/CompressDialog.cpp (solidLogSize -> SolidBlockSize):
+           0 : non-solid, >= 64 : fully solid, other : (1 << BlockLogSize).
+           kSolidLog_FullSolid is 64, so the old (1ULL << BlockLogSize) was
+           also undefined behaviour for the "Solid" entry of the dialog. */
+        UInt64 solidBlockSize = 0;
+        if (fo.BlockLogSize != 0)
+          solidBlockSize = (fo.BlockLogSize >= 64) ?
+              (UInt64)(Int64)-1 :
+              ((UInt64)1 << fo.BlockLogSize);
         params += " -ms=";
-        ConvertUInt64ToString(1ULL << fo.BlockLogSize, temp);
+        ConvertUInt64ToString(solidBlockSize, temp);
         params += temp;
         params += "b";
       }
 
-      if (fo.NumThreads && fo.NumThreads != -1)
+      if (fo.NumThreads && fo.NumThreads != kNotDefined)
       {
         params += " -mmt=";
         ConvertUInt32ToString(fo.NumThreads, temp);


### PR DESCRIPTION
Fixes #479.

The Explorer entry "Add to `<name>`.7z" does not open the compress dialog.
`CompressFiles()` (`CPP/7zip/UI/Common/CompressCall.cpp`) instead translates the
settings that the dialog previously stored in the registry into `-m` switches
for 7zG.exe.

`NCompression::CFormatOptions` uses `(UInt32)(Int32)-1` as its "not specified"
marker (`ZipRegistry.h:122-135`). It is what `Key_Get_UInt32()` returns for an
absent registry value (`ZipRegistry.cpp:48-52`), what `Key_Set_UInt32()` round
trips (`ZipRegistry.cpp:39-45`), and what `FindRegistryFormatAlways()` produces
when the format has no registry key at all. `Level`, `Dictionary` and
`BlockLogSize` were tested for truthiness only, so the marker was forwarded
verbatim:

```
-t7z -mx=4294967295 -md=4294967295b -ms=9223372036854775808b
```

`NumThreads` already had the correct `!= -1` test (d994c0cd, gh-401); this
applies the same rule to the other three fields through a named constant.

Full root cause analysis and measurements are in the issue. The short version:
`-md=4294967295b` makes 7-Zip size the LZMA2 window to the input file, so the
peak memory of the one-click command grows with the input instead of staying
bounded, and on a large enough file it ends in "Out of memory".

This code path is specific to this fork: upstream `CompressFiles()` (`ip7z/7zip`
at tag `26.02`, `CompressCall.cpp:186-240`) adds `-t<type>` and no `-m` switches
at all, which is what 69364765 described when the block was introduced in
17.00-v1.2.0-R2. Nothing needs to be reported upstream.

## Commits

1. **don't send the registry "not specified" marker to 7zG** — the actual fix
   for #479. Also covers two related defects in the same block:
   * level 0 (Store) was dropped by `if (fo.Level)`, so the archive was written
     with the default level;
   * `kSolidLog_FullSolid` is 64, so the dialog's **Solid** entry made
     `1ULL << fo.BlockLogSize` shift by 64 (undefined behaviour; `-ms=1b` with
     MSVC/x64, i.e. a *non*-solid archive), and **Non-solid** (`BlockLogSize`
     0) was dropped by the truthiness test and produced a *solid* archive. The
     mapping now mirrors `CCompressDialog::OnOK()`
     (`CompressDialog.cpp:1259-1268`) branch for branch.
2. **forward the "Memory usage" limit of the dialog too** — `fo.MemUse` was
   never read, so the one-click command ignored the very setting that exists to
   keep compression inside the available RAM. It is empty for the default
   entry, so nothing changes unless the user picked a limit.
   **This commit is independent and can be dropped** if you prefer to keep the
   change minimal.

## Behaviour with an already configured profile

Unchanged, except where master was demonstrably wrong. For a normal saved
configuration (`LZMA2 / Normal / 16 MiB / 4 GiB solid blocks / 8 threads`) the
generated switch string is character for character the same as before.

## How I verified it

* A standalone program that links the project's real
  `NCompression::CFormatOptions` and `UString` and runs a verbatim copy of the
  old and the new block over 11 stored configurations, printing the generated
  switch string for each. Fresh profile, "auto" everywhere, normal config,
  level 0, Solid, Non-solid, zstd, memory limit, and the two zip cases.
* The switch strings from that program fed to the `7z.exe` of this tree:
  * peak RSS and dictionary size for 50/100/200 MiB inputs (table in the issue);
  * `-mx=4294967295` produces a byte-identical archive to no `-mx` at all and a
    different one from `-mx=9`, confirming it is treated as "not defined";
  * `-ms=1b` produces an archive byte-identical to `-ms=off`, confirming the
    inverted solid setting;
  * `-ms=0b` produces an archive byte-identical to `-ms=off`, confirming the new
    non-solid mapping;
  * `-mmemuse=2G` and `-mmemuse=200M` produce archives byte-identical to
    `-mmemuse=2147483648b` and `-mmemuse=209715200b`, confirming that the
    registry spelling and the `<bytes>b` spelling the dialog uses are
    equivalent.
* `CPP/7zip/UI/FileManager` (7zFM.exe) and `CPP/7zip/UI/Explorer` (7-zip.dll) —
  the two targets that compile this file — build clean with MSVC v143 x64, no
  new warnings, and I byte-searched both binaries for the new string literal to
  make sure I was not testing a stale object file.

I am happy to attach the POC sources if that is useful; I left them out of the
PR to keep the diff to the one file.

## Not addressed here

* `fo.Order` (word size / PPMd order) and `fo.EncryptionMethod` are stored by
  the dialog but still not forwarded by the one-click path. Forwarding `Order`
  correctly needs the `fb` / `o` distinction that `SetOutProperties()` makes
  from the method, which is more than a marker check; I left it out rather than
  guess.
* `fo.Method`, `fo.Options` and now `fo.MemUse` are concatenated into the 7zG
  command line without quoting. That is pre-existing behaviour and the values
  come from the user's own HKCU, so no privilege boundary is crossed, but a
  review bot will very likely point at it.
* There is no automated test. `tests/` is a Tcl suite that drives the `7z` CLI;
  the Explorer to 7zG path is not reachable from it, which is why I built the
  standalone POC instead.
